### PR TITLE
Huasifei WH3000 LAN fix

### DIFF
--- a/target/linux/mediatek/files-5.4/arch/arm64/boot/dts/mediatek/mt7981b-huasifei-wh3000-emmc.dts
+++ b/target/linux/mediatek/files-5.4/arch/arm64/boot/dts/mediatek/mt7981b-huasifei-wh3000-emmc.dts
@@ -1,660 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
+#include "mt7981.dtsi"
+
 / {
-	compatible = "huasifei,wh3000-emmc", "mediatek,mt7981";
-	interrupt-parent = <0x01>;
-	#address-cells = <0x02>;
-	#size-cells = <0x02>;
 	model = "Huasifei WH3000";
-
-	cpus {
-		#address-cells = <0x01>;
-		#size-cells = <0x00>;
-
-		cpu@0 {
-			device_type = "cpu";
-			compatible = "arm,cortex-a53";
-			enable-method = "psci";
-			reg = <0x00>;
-		};
-
-		cpu@1 {
-			device_type = "cpu";
-			compatible = "arm,cortex-a53";
-			enable-method = "psci";
-			reg = <0x01>;
-		};
-	};
-
-	pwm@10048000 {
-		compatible = "mediatek,mt7981-pwm";
-		reg = <0x00 0x10048000 0x00 0x1000>;
-		#pwm-cells = <0x02>;
-		clocks = <0x02 0x0d 0x02 0x0c 0x02 0x0e 0x02 0x0f 0x02 0x10>;
-		clock-names = "top", "main", "pwm1", "pwm2", "pwm3";
-	};
-
-	thermal-zones {
-
-		cpu-thermal {
-			polling-delay-passive = <0x3e8>;
-			polling-delay = <0x3e8>;
-			thermal-sensors = <0x03 0x00>;
-		};
-	};
-
-	thermal@1100c800 {
-		#thermal-sensor-cells = <0x01>;
-		compatible = "mediatek,mt7981-thermal";
-		reg = <0x00 0x1100c800 0x00 0x800>;
-		interrupts = <0x00 0x8a 0x04>;
-		clocks = <0x02 0x1c 0x02 0x2f 0x02 0x30>;
-		clock-names = "therm", "auxadc", "adc_32k";
-		mediatek,auxadc = <0x04>;
-		mediatek,apmixedsys = <0x05>;
-		nvmem-cells = <0x06>;
-		nvmem-cell-names = "calibration-data";
-		phandle = <0x03>;
-	};
-
-	adc@1100d000 {
-		compatible = "mediatek,mt7981-auxadc", "mediatek,mt7622-auxadc";
-		reg = <0x00 0x1100d000 0x00 0x1000>;
-		clocks = <0x02 0x2f 0x02 0x30>;
-		clock-names = "main", "32k";
-		#io-channel-cells = <0x01>;
-		phandle = <0x04>;
-	};
-
-	wed@15010000 {
-		compatible = "mediatek,wed";
-		wed_num = <0x02>;
-		pci_slot_map = <0x00 0x01>;
-		reg = <0x00 0x15010000 0x00 0x1000 0x00 0x15011000 0x00 0x1000>;
-		interrupt-parent = <0x01>;
-		interrupts = <0x00 0xcd 0x04 0x00 0xce 0x04>;
-	};
-
-	wdma@15104800 {
-		compatible = "mediatek,wed-wdma";
-		reg = <0x00 0x15104800 0x00 0x400 0x00 0x15104c00 0x00 0x400>;
-	};
-
-	ap2woccif@151A5000 {
-		compatible = "mediatek,ap2woccif";
-		reg = <0x00 0x151a5000 0x00 0x1000 0x00 0x151ad000 0x00 0x1000>;
-		interrupt-parent = <0x01>;
-		interrupts = <0x00 0xd3 0x04 0x00 0xd4 0x04>;
-	};
-
-	wocpu0_ilm@151E0000 {
-		compatible = "mediatek,wocpu0_ilm";
-		reg = <0x00 0x151e0000 0x00 0x8000>;
-	};
-
-	wocpu_dlm@151E8000 {
-		compatible = "mediatek,wocpu_dlm";
-		reg = <0x00 0x151e8000 0x00 0x2000 0x00 0x151f8000 0x00 0x2000>;
-		resets = <0x07 0x00>;
-		reset-names = "wocpu_rst";
-	};
-
-	wocpu_boot@15194000 {
-		compatible = "mediatek,wocpu_boot";
-		reg = <0x00 0x15194000 0x00 0x1000>;
-	};
-
-	reserved-memory {
-		#address-cells = <0x02>;
-		#size-cells = <0x02>;
-		ranges;
-
-		secmon@43000000 {
-			reg = <0x00 0x43000000 0x00 0x30000>;
-			no-map;
-		};
-
-		wmcpu-reserved@47C80000 {
-			compatible = "mediatek,wmcpu-reserved";
-			no-map;
-			reg = <0x00 0x47c80000 0x00 0x100000>;
-			phandle = <0x17>;
-		};
-
-		wocpu0_emi@47D80000 {
-			compatible = "mediatek,wocpu0_emi";
-			no-map;
-			reg = <0x00 0x47d80000 0x00 0x40000>;
-			shared = <0x00>;
-		};
-
-		wocpu_data@47DC0000 {
-			compatible = "mediatek,wocpu_data";
-			no-map;
-			reg = <0x00 0x47dc0000 0x00 0x240000>;
-			shared = <0x01>;
-		};
-	};
-
-	psci {
-		compatible = "arm,psci-0.2";
-		method = "smc";
-	};
-
-	oscillator@0 {
-		compatible = "fixed-clock";
-		#clock-cells = <0x00>;
-		clock-frequency = <0x2625a00>;
-		clock-output-names = "clkxtal";
-		phandle = <0x1d>;
-	};
-
-	infracfg_ao@10001000 {
-		compatible = "mediatek,mt7981-infracfg_ao", "syscon";
-		reg = <0x00 0x10001000 0x00 0x68>;
-		#clock-cells = <0x01>;
-		phandle = <0x02>;
-	};
-
-	infracfg@10001040 {
-		compatible = "mediatek,mt7981-infracfg", "syscon";
-		reg = <0x00 0x10001068 0x00 0x1000>;
-		#clock-cells = <0x01>;
-		phandle = <0x09>;
-	};
-
-	topckgen@1001B000 {
-		compatible = "mediatek,mt7981-topckgen", "syscon";
-		reg = <0x00 0x1001b000 0x00 0x1000>;
-		#clock-cells = <0x01>;
-		phandle = <0x08>;
-	};
-
-	apmixedsys@1001E000 {
-		compatible = "mediatek,mt7981-apmixedsys", "syscon";
-		reg = <0x00 0x1001e000 0x00 0x1000>;
-		#clock-cells = <0x01>;
-		phandle = <0x05>;
-	};
-
-	dummy_system_clk {
-		compatible = "fixed-clock";
-		clock-frequency = <0x2625a00>;
-		#clock-cells = <0x00>;
-		phandle = <0x19>;
-	};
-
-	dummy_gpt_clk {
-		compatible = "fixed-clock";
-		clock-frequency = <0x1312d00>;
-		#clock-cells = <0x00>;
-	};
-
-	timer {
-		compatible = "arm,armv8-timer";
-		interrupt-parent = <0x01>;
-		clock-frequency = <0xc65d40>;
-		interrupts = <0x01 0x0d 0x08 0x01 0x0e 0x08 0x01 0x0b 0x08 0x01 0x0a 0x08>;
-	};
-
-	watchdog@1001c000 {
-		compatible = "mediatek,mt7622-wdt", "mediatek,mt6589-wdt";
-		reg = <0x00 0x1001c000 0x00 0x1000>;
-		interrupts = <0x00 0x6e 0x04>;
-		#reset-cells = <0x01>;
-		status = "okay";
-	};
-
-	interrupt-controller@c000000 {
-		compatible = "arm,gic-v3";
-		#interrupt-cells = <0x03>;
-		interrupt-parent = <0x01>;
-		interrupt-controller;
-		reg = <0x00 0xc000000 0x00 0x40000 0x00 0xc080000 0x00 0x200000>;
-		interrupts = <0x01 0x09 0x04>;
-		phandle = <0x01>;
-	};
-
-	trng@1020f000 {
-		compatible = "mediatek,mt7981-rng";
-	};
-
-	serial@11002000 {
-		compatible = "mediatek,mt6577-uart";
-		reg = <0x00 0x11002000 0x00 0x400>;
-		interrupts = <0x00 0x7b 0x04>;
-		clocks = <0x02 0x1e>;
-		assigned-clocks = <0x08 0x50 0x02 0x00>;
-		assigned-clock-parents = <0x08 0x00 0x09 0x01>;
-		status = "okay";
-	};
-
-	serial@11003000 {
-		compatible = "mediatek,mt6577-uart";
-		reg = <0x00 0x11003000 0x00 0x400>;
-		interrupts = <0x00 0x7c 0x04>;
-		clocks = <0x02 0x1f>;
-		assigned-clocks = <0x08 0x50 0x02 0x01>;
-		assigned-clock-parents = <0x08 0x00 0x09 0x01>;
-		status = "disabled";
-	};
-
-	serial@11004000 {
-		compatible = "mediatek,mt6577-uart";
-		reg = <0x00 0x11004000 0x00 0x400>;
-		interrupts = <0x00 0x7d 0x04>;
-		clocks = <0x02 0x20>;
-		assigned-clocks = <0x08 0x50 0x02 0x02>;
-		assigned-clock-parents = <0x08 0x00 0x09 0x01>;
-		status = "disabled";
-	};
-
-	i2c@11007000 {
-		compatible = "mediatek,mt7981-i2c";
-		reg = <0x00 0x11007000 0x00 0x1000 0x00 0x10217080 0x00 0x80>;
-		interrupts = <0x00 0x88 0x04>;
-		clock-div = <0x01>;
-		clocks = <0x02 0x1d 0x02 0x19>;
-		clock-names = "main", "dma";
-		#address-cells = <0x01>;
-		#size-cells = <0x00>;
-		status = "disabled";
-	};
-
-	pcie@11280000 {
-		compatible = "mediatek,mt7981-pcie", "mediatek,mt7986-pcie";
-		device_type = "pci";
-		reg = <0x00 0x11280000 0x00 0x4000>;
-		reg-names = "pcie-mac";
-		#address-cells = <0x03>;
-		#size-cells = <0x02>;
-		interrupts = <0x00 0xa8 0x04>;
-		bus-range = <0x00 0xff>;
-		ranges = <0x82000000 0x00 0x20000000 0x00 0x20000000 0x00 0x10000000>;
-		status = "disabled";
-		clocks = <0x02 0x38 0x02 0x39 0x02 0x3a 0x02 0x3b>;
-		phys = <0x0a 0x02>;
-		phy-names = "pcie-phy";
-		#interrupt-cells = <0x01>;
-		interrupt-map-mask = <0x00 0x00 0x00 0x07>;
-		interrupt-map = <0x00 0x00 0x00 0x01 0x0b 0x00 0x00 0x00 0x00 0x02 0x0b 0x01 0x00 0x00 0x00 0x03 0x0b 0x02 0x00 0x00 0x00 0x04 0x0b 0x03>;
-
-		interrupt-controller {
-			interrupt-controller;
-			#address-cells = <0x00>;
-			#interrupt-cells = <0x01>;
-			phandle = <0x0b>;
-		};
-	};
-
-	crypto@10320000 {
-		compatible = "inside-secure,safexcel-eip97";
-		reg = <0x00 0x10320000 0x00 0x40000>;
-		interrupts = <0x00 0x74 0x04 0x00 0x75 0x04 0x00 0x76 0x04 0x00 0x77 0x04>;
-		interrupt-names = "ring0", "ring1", "ring2", "ring3";
-		clocks = <0x08 0x42>;
-		clock-names = "top_eip97_ck";
-		assigned-clocks = <0x08 0x63>;
-		assigned-clock-parents = <0x08 0x15>;
-	};
-
-	pinctrl@11d00000 {
-		compatible = "mediatek,mt7981-pinctrl";
-		reg = <0x00 0x11d00000 0x00 0x1000 0x00 0x11c00000 0x00 0x1000 0x00 0x11c10000 0x00 0x1000 0x00 0x11d20000 0x00 0x1000 0x00 0x11e00000 0x00 0x1000 0x00 0x11e20000 0x00 0x1000 0x00 0x11f00000 0x00 0x1000 0x00 0x11f10000 0x00 0x1000 0x00 0x1000b000 0x00 0x1000>;
-		reg-names = "gpio_base", "iocfg_rt_base", "iocfg_rm_base", "iocfg_rb_base", "iocfg_lb_base", "iocfg_bl_base", "iocfg_tm_base", "iocfg_tl_base", "eint";
-		gpio-controller;
-		#gpio-cells = <0x02>;
-		gpio-ranges = <0x0c 0x00 0x00 0x38>;
-		interrupt-controller;
-		interrupts = <0x00 0xe1 0x04>;
-		interrupt-parent = <0x01>;
-		#interrupt-cells = <0x02>;
-		phandle = <0x0c>;
-
-		mmc0-pins-default {
-			phandle = <0x14>;
-
-			mux {
-				function = "flash";
-				groups = "emmc_45";
-			};
-		};
-
-		mmc0-pins-uhs {
-			phandle = <0x15>;
-
-			mux {
-				function = "flash";
-				groups = "emmc_45";
-			};
-		};
-	};
-
-	syscon@15000000 {
-		#address-cells = <0x01>;
-		#size-cells = <0x01>;
-		compatible = "mediatek,mt7981-ethsys", "syscon";
-		reg = <0x00 0x15000000 0x00 0x1000>;
-		#clock-cells = <0x01>;
-		#reset-cells = <0x01>;
-		phandle = <0x0d>;
-
-		reset-controller {
-			compatible = "ti,syscon-reset";
-			#reset-cells = <0x01>;
-			ti,reset-bits = <0x34 0x04 0x34 0x04 0x34 0x04 0x28>;
-			phandle = <0x07>;
-		};
-	};
-
-	ethernet@15100000 {
-		compatible = "mediatek,mt7981-eth";
-		reg = <0x00 0x15100000 0x00 0x80000>;
-		interrupts = <0x00 0xc4 0x04 0x00 0xc5 0x04 0x00 0xc6 0x04 0x00 0xc7 0x04>;
-		clocks = <0x0d 0x00 0x0d 0x01 0x0d 0x02 0x0d 0x03 0x0e 0x00 0x0e 0x01 0x0e 0x02 0x0e 0x03 0x0f 0x00 0x0f 0x01 0x0f 0x02 0x0f 0x03>;
-		clock-names = "fe", "gp2", "gp1", "wocpu0", "sgmii_tx250m", "sgmii_rx250m", "sgmii_cdr_ref", "sgmii_cdr_fb", "sgmii2_tx250m", "sgmii2_rx250m", "sgmii2_cdr_ref", "sgmii2_cdr_fb";
-		assigned-clocks = <0x08 0x60 0x08 0x61>;
-		assigned-clock-parents = <0x08 0x1b 0x08 0x22>;
-		mediatek,ethsys = <0x0d>;
-		mediatek,sgmiisys = <0x0e 0x0f>;
-		mediatek,infracfg = <0x10>;
-		#reset-cells = <0x01>;
-		#address-cells = <0x01>;
-		#size-cells = <0x00>;
-		status = "okay";
-
-		mac@0 {
-			compatible = "mediatek,eth-mac";
-			reg = <0x00>;
-			phy-mode = "2500base-x";
-			phy-handle = <0x11>;
-		};
-
-		mac@1 {
-			compatible = "mediatek,eth-mac";
-			reg = <0x01>;
-			phy-mode = "gmii";
-			phy-handle = <0x12>;
-		};
-
-		mdio-bus {
-			#address-cells = <0x01>;
-			#size-cells = <0x00>;
-
-			phy@0 {
-				compatible = "ethernet-phy-id03a2.9461";
-				reg = <0x00>;
-				nvmem-cells = <0x13>;
-				nvmem-cell-names = "phy-cal-data";
-				phandle = <0x12>;
-			};
-
-			ethernet-phy@1 {
-				compatible = "ethernet-phy-ieee802.3-c45";
-				reg = <0x01>;
-				reset-assert-us = <0x186a0>;
-				reset-deassert-us = <0x186a0>;
-				reset-gpios = <0x0c 0x27 0x01>;
-				interrupts = <0x26 0x08>;
-				interrupt-parent = <0x0c>;
-				realtek,aldps-enable;
-				phandle = <0x11>;
-			};
-		};
-	};
-
-	hnat@15000000 {
-		compatible = "mediatek,mtk-hnat_v4";
-		reg = <0x00 0x15100000 0x00 0x80000>;
-		resets = <0x0d 0x00>;
-		reset-names = "mtketh";
-		status = "okay";
-		mtketh-wan = "eth1";
-		mtketh-lan = "eth0";
-		mtketh-max-gmac = <0x02>;
-		mtketh-max-ppe = <0x02>;
-	};
-
-	syscon@10060000 {
-		compatible = "mediatek,mt7981-sgmiisys_0", "syscon";
-		reg = <0x00 0x10060000 0x00 0x1000>;
-		pn_swap;
-		#clock-cells = <0x01>;
-		phandle = <0x0e>;
-	};
-
-	syscon@10070000 {
-		compatible = "mediatek,mt7981-sgmiisys_1", "syscon";
-		reg = <0x00 0x10070000 0x00 0x1000>;
-		#clock-cells = <0x01>;
-		phandle = <0x0f>;
-	};
-
-	topmisc@11d10000 {
-		compatible = "mediatek,mt7981-topmisc", "syscon";
-		reg = <0x00 0x11d10000 0x00 0x10000>;
-		#clock-cells = <0x01>;
-		phandle = <0x10>;
-	};
-
-	snfi@11005000 {
-		compatible = "mediatek,mt7986-snand";
-		reg = <0x00 0x11005000 0x00 0x1000 0x00 0x11006000 0x00 0x1000>;
-		reg-names = "nfi", "ecc";
-		interrupts = <0x00 0x79 0x04>;
-		clocks = <0x02 0x24 0x02 0x23 0x02 0x25>;
-		clock-names = "pad_clk", "nfi_clk", "nfi_hclk";
-		assigned-clocks = <0x08 0x4d 0x08 0x4c>;
-		assigned-clock-parents = <0x08 0x06 0x08 0x06>;
-		#address-cells = <0x01>;
-		#size-cells = <0x00>;
-		status = "disabled";
-	};
-
-	mmc@11230000 {
-		compatible = "mediatek,mt7986-mmc", "mediatek,mt7981-mmc";
-		reg = <0x00 0x11230000 0x00 0x1000 0x00 0x11c20000 0x00 0x1000>;
-		interrupts = <0x00 0x8f 0x04>;
-		clocks = <0x08 0x33 0x08 0x34 0x02 0x2b>;
-		assigned-clocks = <0x08 0x54 0x08 0x55>;
-		assigned-clock-parents = <0x08 0x02 0x08 0x1c>;
-		clock-names = "source", "hclk", "source_cg";
-		status = "okay";
-		bus-width = <0x08>;
-		max-frequency = <52000000>;
-		no-sd;
-		no-sdio;
-		non-removable;
-		pinctrl-names = "default", "state_uhs";
-		pinctrl-0 = <0x14>;
-		pinctrl-1 = <0x15>;
-		vmmc-supply = <0x16>;
-	};
-
-	wbsys@18000000 {
-		compatible = "mediatek,wbsys";
-		reg = <0x00 0x18000000 0x00 0x1000000>;
-		interrupts = <0x00 0xd5 0x04 0x00 0xd6 0x04 0x00 0xd7 0x04 0x00 0xd8 0x04>;
-		chip_id = <0x7981>;
-	};
-
-	wed_pcie@10003000 {
-		compatible = "mediatek,wed_pcie";
-		reg = <0x00 0x10003000 0x00 0x10>;
-	};
-
-	spi@1100a000 {
-		compatible = "mediatek,ipm-spi-quad";
-		reg = <0x00 0x1100a000 0x00 0x100>;
-		interrupts = <0x00 0x8c 0x04>;
-		clocks = <0x08 0x02 0x08 0x4e 0x02 0x26 0x02 0x28>;
-		clock-names = "parent-clk", "sel-clk", "spi-clk", "spi-hclk";
-		status = "disabled";
-	};
-
-	spi@1100b000 {
-		compatible = "mediatek,ipm-spi-single";
-		reg = <0x00 0x1100b000 0x00 0x100>;
-		interrupts = <0x00 0x8d 0x04>;
-		clocks = <0x08 0x02 0x08 0x4f 0x02 0x27 0x02 0x29>;
-		clock-names = "parent-clk", "sel-clk", "spi-clk", "spi-hclk";
-		status = "disabled";
-	};
-
-	spi@11009000 {
-		compatible = "mediatek,ipm-spi-quad";
-		reg = <0x00 0x11009000 0x00 0x100>;
-		interrupts = <0x00 0x8e 0x04>;
-		clocks = <0x08 0x02 0x08 0x4e 0x02 0x21 0x02 0x22>;
-		clock-names = "parent-clk", "sel-clk", "spi-clk", "spi-hclk";
-		status = "disabled";
-	};
-
-	consys@10000000 {
-		compatible = "mediatek,mt7981-consys";
-		reg = <0x00 0x10000000 0x00 0x8600000>;
-		memory-region = <0x17>;
-	};
-
-	xhci@11200000 {
-		compatible = "mediatek,mt7986-xhci", "mediatek,mtk-xhci";
-		reg = <0x00 0x11200000 0x00 0x2e00 0x00 0x11203e00 0x00 0x100>;
-		reg-names = "mac", "ippc";
-		interrupts = <0x00 0xad 0x04>;
-		phys = <0x18 0x03 0x0a 0x04>;
-		clocks = <0x19 0x19 0x19 0x19 0x19>;
-		clock-names = "sys_ck", "xhci_ck", "ref_ck", "mcu_ck", "dma_ck";
-		#address-cells = <0x02>;
-		#size-cells = <0x02>;
-		mediatek,u3p-dis-msk = <0x00>;
-		status = "okay";
-	};
-
-	usb-phy@11e10000 {
-		compatible = "mediatek,mt7986", "mediatek,generic-tphy-v2";
-		#address-cells = <0x02>;
-		#size-cells = <0x02>;
-		ranges;
-		status = "okay";
-
-		usb-phy@11e10000 {
-			reg = <0x00 0x11e10000 0x00 0x700>;
-			clocks = <0x19>;
-			clock-names = "ref";
-			#phy-cells = <0x01>;
-			status = "okay";
-			phandle = <0x18>;
-		};
-
-		usb-phy@11e10700 {
-			reg = <0x00 0x11e10700 0x00 0x900>;
-			clocks = <0x19>;
-			clock-names = "ref";
-			#phy-cells = <0x01>;
-			mediatek,syscon-type = <0x10 0x218 0x00>;
-			nvmem-cells = <0x1a 0x1b 0x1c>;
-			nvmem-cell-names = "intr", "rx_imp", "tx_imp";
-			status = "okay";
-			phandle = <0x0a>;
-		};
-	};
-
-	regulator-3p3v {
-		compatible = "regulator-fixed";
-		regulator-name = "fixed-3.3V";
-		regulator-min-microvolt = <0x325aa0>;
-		regulator-max-microvolt = <0x325aa0>;
-		regulator-boot-on;
-		regulator-always-on;
-		phandle = <0x16>;
-	};
-
-	clkitg {
-		compatible = "simple-bus";
-
-		bring-up {
-			compatible = "mediatek,clk-bring-up";
-			clocks = <0x05 0x00 0x05 0x01 0x05 0x02 0x05 0x03 0x05 0x04 0x05 0x05 0x05 0x06 0x05 0x07 0x09 0x00 0x1d 0x09 0x02 0x09 0x03 0x09 0x04 0x1d 0x09 0x06 0x09 0x07 0x1d 0x1d 0x1d 0x1d 0x09 0x0c 0x09 0x0d 0x09 0x0e 0x09 0x0f 0x09 0x10 0x09 0x11 0x1d 0x1d 0x1d 0x1d 0x1d 0x09 0x17 0x09 0x18 0x09 0x1a 0x09 0x1b 0x09 0x1c 0x09 0x1d 0x09 0x1e 0x09 0x1f 0x09 0x20 0x09 0x21 0x1d 0x09 0x23 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x02 0x0b 0x1d 0x1d 0x1d 0x1d 0x02 0x11 0x1d 0x1d 0x1d 0x1d 0x1d 0x02 0x17 0x1d 0x02 0x19 0x02 0x1a 0x02 0x1b 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x02 0x2a 0x02 0x2b 0x02 0x2c 0x02 0x2d 0x02 0x2e 0x1d 0x1d 0x02 0x31 0x02 0x32 0x02 0x33 0x02 0x34 0x02 0x35 0x02 0x36 0x02 0x37 0x1d 0x1d 0x1d 0x08 0x01 0x1d 0x08 0x05 0x08 0x06 0x08 0x07 0x08 0x04 0x08 0x09 0x08 0x0c 0x08 0x0f 0x08 0x10 0x08 0x12 0x08 0x14 0x08 0x15 0x08 0x16 0x08 0x17 0x08 0x19 0x08 0x1a 0x1d 0x08 0x1d 0x08 0x1e 0x08 0x21 0x1d 0x08 0x24 0x08 0x25 0x1d 0x08 0x29 0x08 0x26 0x08 0x2b 0x08 0x2a 0x1d 0x08 0x31 0x1d 0x1d 0x1d 0x08 0x56 0x08 0x37 0x08 0x3d 0x08 0x3e 0x08 0x3f 0x08 0x45 0x08 0x41 0x08 0x46 0x08 0x47 0x08 0x48 0x08 0x49 0x08 0x4a 0x08 0x3a 0x1d 0x1d 0x1d 0x1d 0x08 0x52 0x1d 0x1d 0x1d 0x08 0x56 0x08 0x57 0x08 0x58 0x08 0x59 0x08 0x5a 0x08 0x5b 0x08 0x5c 0x08 0x5d 0x08 0x5e 0x08 0x5f 0x1d 0x1d 0x08 0x62 0x08 0x5e 0x1d 0x08 0x64 0x08 0x56 0x08 0x69 0x08 0x6a 0x08 0x6b 0x08 0x6c>;
-			clock-names = "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", "62", "63", "64", "65", "66", "67", "68", "69", "70", "71", "72", "73", "74", "75", "76", "77", "78", "79", "80", "81", "82", "83", "84", "85", "86", "87", "88", "89", "90", "91", "92", "93", "94", "95", "96", "97", "98", "99", "100", "101", "102", "103", "104", "105", "106", "107", "108", "109", "110", "111", "112", "113", "114", "115", "116", "117", "118", "119", "120", "121", "122", "123", "124", "125", "126", "127", "128", "129", "130", "131", "132", "133", "134", "135", "136", "137", "138", "139", "140", "141", "142", "143", "144", "145", "146", "147", "148", "149", "150", "151", "152", "153", "154", "155", "156", "157", "158", "159", "160", "161", "162", "163", "164", "165", "166", "167", "168", "169", "170", "171", "172", "173", "174", "175", "176", "177", "178", "179", "180", "181", "182", "183";
-		};
-	};
-
-	efuse@11f20000 {
-		compatible = "mediatek,efuse";
-		reg = <0x00 0x11f20000 0x00 0x1000>;
-		#address-cells = <0x01>;
-		#size-cells = <0x01>;
-
-		calib@274 {
-			reg = <0x274 0x0c>;
-			phandle = <0x06>;
-		};
-
-		calib@8dc {
-			reg = <0x8dc 0x10>;
-			phandle = <0x13>;
-		};
-
-		usb3-rx-imp@8c8 {
-			reg = <0x8c8 0x01>;
-			bits = <0x00 0x05>;
-			phandle = <0x1b>;
-		};
-
-		usb3-tx-imp@8c8 {
-			reg = <0x8c8 0x02>;
-			bits = <0x05 0x05>;
-			phandle = <0x1c>;
-		};
-
-		usb3-intr@8c9 {
-			reg = <0x8c9 0x01>;
-			bits = <0x02 0x06>;
-			phandle = <0x1a>;
-		};
-	};
-
-	audio-controller@11210000 {
-		compatible = "mediatek,mt79xx-audio";
-		reg = <0x00 0x11210000 0x00 0x9000>;
-		interrupts = <0x00 0x6a 0x04>;
-		clocks = <0x02 0x12 0x02 0x13 0x02 0x14 0x02 0x15 0x02 0x16 0x08 0x65>;
-		clock-names = "aud_bus_ck", "aud_26m_ck", "aud_l_ck", "aud_aud_ck", "aud_eg2_ck", "aud_sel";
-		assigned-clocks = <0x08 0x65 0x08 0x66 0x08 0x67 0x08 0x68>;
-		assigned-clock-parents = <0x08 0x10 0x08 0x12 0x08 0x10 0x08 0x12>;
-		status = "disabled";
-	};
-
-	ice_debug {
-		compatible = "mediatek,mt7981-ice_debug", "mediatek,mt2701-ice_debug";
-		clocks = <0x02 0x18>;
-		clock-names = "ice_dbg";
-	};
+	compatible = "huasifei,wh3000-emmc", "mediatek,mt7981";
 
 	aliases {
+		serial0 = &uart0;
 		led-boot = "/gpio-leds/led-0";
 		led-failsafe = "/gpio-leds/led-0";
 		led-upgrade = "/gpio-leds/led-0";
 	};
 
-	memory {
-		device_type = "memory";
-		reg = <0x00 0x40000000 0x00 0x40000000>;
+	chosen {
+		bootargs = "root=PARTLABEL=rootfs rootwait";
+		stdout-path = "serial0:115200n8";
 	};
 
 	gpio-keys {
 		compatible = "gpio-keys";
 
-		reset {
-			label = "reset";
-			linux,code = <0x198>;
-			gpios = <0x0c 0x01 0x01>;
+		button-mode {
+			label = "mode";
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
 		};
 
-		wps {
-			label = "wps";
-			linux,code = <0x211>;
-			gpios = <0x0c 0x00 0x01>;
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -672,8 +51,133 @@
 		};
 	};
 
-	chosen {
-		u-boot,bootconf = "config-1";
-		bootargs = "console=ttyS0,115200n1 loglevel=8 \t\t\t    earlycon=uart8250,mmio32,0x11002000 \t\t\t    root=PARTLABEL=rootfs rootwait";
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x40000000>;
 	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4 2>;
+		nvmem-cell-names = "mac-address";
+		phy-mode = "2500base-x";
+		ext-phy-reg = <1>;
+ 		ext-phy-reset-gpios = <&pio 39 0>;
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_4 3>;
+		nvmem-cell-names = "mac-address";
+		phy-mode = "gmii";
+		fixed-link {
+			speed = <1000>;
+			phy-handle = <&phy0>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		phy0: phy@0 {
+			compatible = "ethernet-phy-id03a2.9461";
+			reg = <0>;
+			nvmem-cells = <&phy_calibration>;
+			nvmem-cell-names = "phy-cal-data";
+		};
+	};
+};
+
+&hnat {
+	mtketh-wan = "eth1";
+	mtketh-lan = "eth0";
+	mtketh-ppd = "eth0";
+	mtketh-max-gmac = <2>;
+	mtketh-ppe-num = <2>;
+	status = "okay";
+};
+
+&mmc0 {
+	bus-width = <8>;
+	cap-mmc-highspeed;
+	max-frequency = <52000000>;
+	no-sd;
+	no-sdio;
+	non-removable;
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc0_pins_default>;
+	pinctrl-1 = <&mmc0_pins_uhs>;
+	vmmc-supply = <&reg_3p3v>;
+	status = "okay";
+
+	card@0 {
+		compatible = "mmc-card";
+		reg = <0>;
+
+		block {
+			compatible = "block-device";
+
+			partitions {
+				block-partition-factory {
+					partname = "factory";
+
+					nvmem-layout {
+						compatible = "fixed-layout";
+						#address-cells = <1>;
+						#size-cells = <1>;
+
+						eeprom_factory_0: eeprom@0 {
+							reg = <0x0 0x1000>;
+						};
+
+						macaddr_factory_4: macaddr@4 {
+							compatible = "mac-base";
+							reg = <0x4 0x6>;
+							#nvmem-cell-cells = <1>;
+						};
+					};
+				};
+			};
+		};
+	};
+};
+
+&pio {
+	mmc0_pins_default: mmc0-pins-default {
+		mux {
+			function = "flash";
+			groups = "emmc_45";
+		};
+	};
+
+	mmc0_pins_uhs: mmc0-pins-uhs {
+		mux {
+			function = "flash";
+			groups = "emmc_45";
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&xhci {
+	mediatek,u3p-dis-msk = <0x0>;
+	phys = <&u2port0 PHY_TYPE_USB2>,
+		   <&u3port0 PHY_TYPE_USB3>;
+	status = "okay";
 };


### PR DESCRIPTION
I've managed to fix it copying some parts from Cudy DTS. Now LAN and WAN is working, Wifi also works fine. All MAC addresses are correct. The only thing I am still not sure if USB stuff is correct in this DTS. I don't know how to test it.

When I plug in my external SSD, I got this:
```
xhci-mtk 11200000.xhci: ERROR Transfer event for unknown stream ring slot 1 ep 2
```
I am not sure if it's related to missing kernel modules or DTS itself...

Also I've got this messages during the boot.
```
[   49.268843] efuse_probe: efuse = deaddead
[   49.272914] mt_rbus 0000:00:00.0: Direct firmware load for e2p failed with error -2
[   49.280564] mt_rbus 0000:00:00.0: Falling back to sysfs fallback for: e2p
[   49.293624] WiFi@C01L1,os_load_code_from_bin() 2999: fw not available(/lib/firmware/e2p)
[   49.302582] Use default BIN from:/lib/firmware/MT7981_iPAiLNA_EEPROM.bin.
[   49.309432] 7981@C02L1,rtmp_ee_flash_init() 444: The EEPROM in Flash is wrong, use default
[   49.320246] 7981@C02L1,is_cal_free_ic() 830: [a-die version:1]
[   51.823079] 7981@C17L1,RTMPReadTxPwrPerRate() 450: (450): Don't Support this now!
[   51.830596] 7981@C01L1,AntCfgInit() 3118: Not support for HIF_MT yet!
```