### PR TITLE
[BPI r3 mini] Add support new X75 5G module 

### DIFF
--- a/target/linux/mediatek/files-5.4/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3mini-emmc.dts
+++ b/target/linux/mediatek/files-5.4/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3mini-emmc.dts
@@ -71,6 +71,24 @@
                 regulator-always-on;
         };
 
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&pio 20 GPIO_ACTIVE_LOW>;
+		regulator-boot-on;
+	};
+
 	sound {
 		compatible = "mediatek,mt7986-wm8960-machine";
 		mediatek,platform = <&afe>;
@@ -285,6 +303,15 @@
 	status = "disabled";
 };
 
+/* Add usb pin control  */
+&xhci {
+        pinctrl-names = "default";
+        pinctrl-0 = <&usb_ngff_pins>;
+        vusb33-supply = <&reg_3p3v>;
+        vbus-supply = <&usb_vbus>;
+        status = "okay";
+};
+
 &mmc0 {
         pinctrl-names = "default", "state_uhs";
         pinctrl-0 = <&mmc0_pins_default>;
@@ -320,11 +347,40 @@
 */
 
 &pio {
-	/* GPIO 11 NGFF_GNSS_OFF. output-high: enable, output-low: disable */
-	gnss_off {
-		gpio-hog;
-		gpios = <11 GPIO_ACTIVE_HIGH>;
-		output-high;
+
+/* Define usb_ngff_pins SPI1_CS --> GPIO 32 */
+
+	usb_ngff_pins: usb-ngff-pins {
+		ngff-gnss-off {
+			pins = "GPIO_6";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <1>;
+		};
+		ngff-pe-rst {
+			pins = "GPIO_7";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <1>;
+		};
+		ngff-wwan-off {
+			pins = "GPIO_8";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <1>;
+		};
+		ngff-pwr-off {
+			pins = "GPIO_9";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <1>;
+		};
+		ngff-rst {
+			pins = "GPIO_10";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <1>;
+		};
+		ngff-coex {
+			pins = "SPI1_CS";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <1>;
+		};
 	};
 
         mmc0_pins_default: mmc0-pins-50-to-61-default {

--- a/target/linux/mediatek/files-5.4/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3mini-nand-110m.dts
+++ b/target/linux/mediatek/files-5.4/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3mini-nand-110m.dts
@@ -32,6 +32,24 @@
 			regulator-always-on;
 	};
 
+        reg_5v: regulator-5v {
+                compatible = "regulator-fixed";
+                regulator-name = "fixed-5V";
+                regulator-min-microvolt = <5000000>;
+                regulator-max-microvolt = <5000000>;
+                regulator-boot-on;
+                regulator-always-on;
+        };
+
+        usb_vbus: regulator-usb-vbus {
+                compatible = "regulator-fixed";
+                regulator-name = "usb_vbus";
+                regulator-min-microvolt = <5000000>;
+                regulator-max-microvolt = <5000000>;
+                gpios = <&pio 20 GPIO_ACTIVE_LOW>;
+                regulator-boot-on;
+        };
+
 	sound {
 		compatible = "mediatek,mt7986-wm8960-machine";
 		mediatek,platform = <&afe>;
@@ -194,6 +212,15 @@
 	status = "okay";
 };
 
+/* Add usb pin control  */
+&xhci {
+        pinctrl-names = "default";
+        pinctrl-0 = <&usb_ngff_pins>;
+        vusb33-supply = <&reg_3p3v>;
+        vbus-supply = <&usb_vbus>;
+        status = "okay";
+};
+
 &mmc0 {
         pinctrl-names = "default", "state_uhs";
         pinctrl-0 = <&mmc0_pins_default>;
@@ -227,6 +254,42 @@
 };
 
 &pio {
+
+/* Define usb_ngff_pins SPI1_CS --> GPIO 32 */
+
+        usb_ngff_pins: usb-ngff-pins {
+                ngff-gnss-off {
+                        pins = "GPIO_6";
+                        drive-strength = <8>;
+                        mediatek,pull-up-adv = <1>;
+                };
+                ngff-pe-rst {
+                        pins = "GPIO_7";
+                        drive-strength = <8>;
+                        mediatek,pull-up-adv = <1>;
+                };
+                ngff-wwan-off {
+                        pins = "GPIO_8";
+                        drive-strength = <8>;
+                        mediatek,pull-up-adv = <1>;
+                };
+                ngff-pwr-off {
+                        pins = "GPIO_9";
+                        drive-strength = <8>;
+                        mediatek,pull-up-adv = <1>;
+                };
+                ngff-rst {
+                        pins = "GPIO_10";
+                        drive-strength = <8>;
+                        mediatek,pull-up-adv = <1>;
+                };
+                ngff-coex {
+                        pins = "SPI1_CS";
+                        drive-strength = <8>;
+                        mediatek,pull-up-adv = <1>;
+                };
+        };
+
         mmc0_pins_default: mmc0-pins-50-to-61-default {
                 mux {
                         function = "flash";

--- a/target/linux/mediatek/files-5.4/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3mini-nand.dts
+++ b/target/linux/mediatek/files-5.4/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3mini-nand.dts
@@ -72,6 +72,24 @@
 			regulator-always-on;
 	};
 
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&pio 20 GPIO_ACTIVE_LOW>;
+		regulator-boot-on;
+	};
+
 	sound {
 		compatible = "mediatek,mt7986-wm8960-machine";
 		mediatek,platform = <&afe>;
@@ -286,6 +304,15 @@
 	status = "disabled";
 };
 
+/* Add usb pin control  */
+&xhci {
+	pinctrl-names = "default";
+	pinctrl-0 = <&usb_ngff_pins>;
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&usb_vbus>;
+	status = "okay";
+};
+
 &mmc0 {
         pinctrl-names = "default", "state_uhs";
         pinctrl-0 = <&mmc0_pins_default>;
@@ -319,11 +346,39 @@
 };
 
 &pio {
-	/* GPIO 11 NGFF_GNSS_OFF. output-high: enable, output-low: disable */
-	gnss_off {
-		gpio-hog;
-		gpios = <11 GPIO_ACTIVE_HIGH>;
-		output-high;
+/* Define usb_ngff_pins SPI1_CS --> GPIO 32 */
+
+	usb_ngff_pins: usb-ngff-pins {
+		ngff-gnss-off {
+			pins = "GPIO_6";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <1>;
+		};
+		ngff-pe-rst {
+			pins = "GPIO_7";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <1>;
+		};
+		ngff-wwan-off {
+			pins = "GPIO_8";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <1>;
+		};
+		ngff-pwr-off {
+			pins = "GPIO_9";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <1>;
+		};
+		ngff-rst {
+			pins = "GPIO_10";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <1>;
+		};
+		ngff-coex {
+			pins = "SPI1_CS";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <1>;
+		};
 	};
 
         mmc0_pins_default: mmc0-pins-50-to-61-default {


### PR DESCRIPTION
This PR add support for new X75 module include Quectel RM551E-GL, Fibocom FM190W-GL, Meig SRM817 on bpi r3 mini

- Correct clock and ngff PIN define
- Adjust reg address mapping
- Add missing interrupt-parent

## Testing
- Boot tested on BPI r3mini
- Verified USB 3.0 device detection via dmesg

Make sure modem set in USB mode, then QCOM/Qualcomm or similar device should appear in logs.

root@ImmortalWrt:~# dmesg | grep -i usb
[   16.266770] usbcore: registered new interface driver qcserial
[   16.272585] usbserial: USB Serial support registered for Qualcomm USB modem
[   17.471304] usb 2-1: new SuperSpeed Gen 1x2 USB device number 2 using xhci-mtk
[   17.514960] usb 2-1: LPM exit latency is zeroed, disabling LPM.
[   17.530940] usb 2-1: GSM modem (1-port) converter now attached to ttyUSB0
[   17.544542] usb 2-1: GSM modem (1-port) converter now attached to ttyUSB1
[   17.558130] usb 2-1: GSM modem (1-port) converter now attached to ttyUSB2
[   17.571510] usb 2-1: GSM modem (1-port) converter now attached to ttyUSB3
[   17.584919] cdc_ether 2-1:1.4 usb0: register 'cdc_ether' at usb-11200000.xhci-1, CDC Ethernet Device, da:f5:77:dc:86:75
[   23.482592] usbserial_generic 2-1:1.6: The "generic" usb-serial driver is only for testing and one-off prototypes.
[   23.492944] usbserial_generic 2-1:1.6: Tell linux-usb@vger.kernel.org to add your device to a proper driver.
[   23.502777] usbserial_generic 2-1:1.6: generic converter detected
[   23.509023] usb 2-1: generic converter now attached to ttyUSB4

root@ImmortalWrt:~# lsusb
Bus 001 Device 001: ID 1d6b:0002 Linux 5.4.284 xhci-hcd xHCI Host Controller
Bus 002 Device 001: ID 1d6b:0003 Linux 5.4.284 xhci-hcd xHCI Host Controller
Bus 002 Device 002: ID 2cb7:0105 QCOM SDXPINN-IDP _SN:XXXXXXXX
