### PR TITLE
Update turboacc uci-default scripts

### DIFF
--- a/package/mtk/applications/luci-app-turboacc-mtk/root/etc/uci-defaults/turboacc
+++ b/package/mtk/applications/luci-app-turboacc-mtk/root/etc/uci-defaults/turboacc
@@ -24,7 +24,7 @@ else
 	uci -q set "turboacc.config.fastpath"="none"
 fi
 
-uci -q set "turboacc.config.fullcone"="1"
+uci -q set "turboacc.config.fullcone"="2"
 
 uci -q commit "turboacc"
 


### PR DESCRIPTION
选项只有0和2，2是Boardcom_FULLCONE_NAT