### PR TITLE
board: wirelesstag zx7981pd add first support.

### DIFF
--- a/package/mtk/applications/mtk-smp/files/smp.sh
+++ b/package/mtk/applications/mtk-smp/files/smp.sh
@@ -745,6 +745,7 @@ setup_model()
 		MT7986_whnat $num_of_wifi $usbnet
 		;;
 	*mt3000* |\
+	*wirelesstag* |\
 	glinet,x3000-emmc |\
 	*xe3000* |\
 	*cudy* |\

--- a/target/linux/mediatek/dts/mt7981b-wirelesstag-zx7981pd.dts
+++ b/target/linux/mediatek/dts/mt7981b-wirelesstag-zx7981pd.dts
@@ -1,0 +1,312 @@
+/dts-v1/;
+
+#include "mt7981.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "Wireless-Tag ZX7981PD";
+	compatible = "wirelesstag","zx7981pd", "mediatek,mt7981";
+
+	aliases {
+		ethernet0 = &gmac0;
+		ethernet1 = &gmac1;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x20000000>;
+	};
+
+
+
+    gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		button-wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+    gpio-leds {
+		compatible = "gpio-leds";
+
+      	led-0 {
+			label = "wt:4g:green";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 11 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+        
+        led-1 {
+			label = "wt:5g:yellow";
+            color = <LED_COLOR_ID_YELLOW>;
+			gpios = <&pio 13 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+        };
+
+        led-2 {
+			label = "wt:5g:blue";
+            color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 9 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+        };
+
+        led-3 {
+			label = "wt:wifi:blue";
+            color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 4 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+        };
+
+        led-4 {
+			label = "wt:power:blue";
+            color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+        };
+
+        led-5 {
+			label = "wt:4g:blue";
+            color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 12 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+        };
+
+        led-6 {
+			label = "wt:4g:yellow";
+            color = <LED_COLOR_ID_YELLOW>;
+			gpios = <&pio 10 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+        };
+    };
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		m2_slot {
+			gpio-export,name = "m2_slot";
+			gpio-export,output = <0>; // OUT_INIT_LOW
+			gpios = <&pio 2 0>;    // GPIO 2, ACTIVE_LOW
+		};
+
+		sim-card_slot {
+			gpio-export,name = "sim-card_slot";
+			gpio-export,output = <1>; // OUT_INIT_LOW
+			gpios = <&pio 25 0>;    // GPIO 15, ACTIVE_LOW
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 (-1)>;
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	// FAKE ETH1 interface dedicated to USB Offload
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+	};
+};
+
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "wan";
+		};
+
+		port@6 {
+			reg = <6>;
+			label = "cpu";
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand: flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00000 0x0100000>;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x0100000 0x0080000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x0200000>;
+			};
+
+			partition@580000 {
+				label = "woem";
+				reg = <0x580000 0xa0000>;
+			};
+
+			partition@620000 {
+				label = "ubi";
+				reg = <0x620000 0x3800000>;
+			};
+
+			partition@3E20000 {
+				label = "ubi2";
+				reg = <0x3E20000 0x3800000>;
+			};
+
+			partition@7620000 {
+				label = "wtinfo";
+				reg = <0x7620000 0x60000>;
+			};
+
+			partition@7680000 {
+				label = "nvram";
+				reg = <0x7680000 0x60000>;
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -172,6 +172,11 @@ zyxel,ex5601-t0-ubootmod)
 	ucidef_set_led_netdev "wifi-24g" "WIFI-2.4G" "green:wifi24g" "phy0-ap0" "link tx rx"
 	ucidef_set_led_netdev "wifi-5g" "WIFI-5G" "green:wifi5g" "phy1-ap0" "link tx rx"
 	;;
+wirelesstag,zx7981pd)
+	ucidef_set_led_default "power" "POWER" "wt:power:blue" "1"
+	ucidef_set_led_netdev "wlan2g" "WLAN2G" "wt:wifi:blue" "rax0" "link"
+	ucidef_set_led_netdev "wlan5g" "WLAN5G" "wt:wifi:blue" "ra0" "link"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -143,6 +143,9 @@ mediatek_setup_interfaces()
 	tplink,re6000xd)
 		ucidef_set_interface_lan "lan1 lan2 eth1"
 		;;
+	wirelesstag,zx7981pd)
+		ucidef_set_interface_lan "lan1 lan2" "wan"
+		;;
 	xiaomi,mi-router-ax3000t|\
 	xiaomi,mi-router-ax3000t-ubootmod|\
 	xiaomi,mi-router-wr30u-stock|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2141,3 +2141,21 @@ define Device/zyxel_nwa50ax-pro
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += zyxel_nwa50ax-pro
+
+define Device/wirelesstag_zx7981pd
+  DEVICE_VENDOR := Wireless-Tag
+  DEVICE_MODEL := ZX7981PD
+  DEVICE_DTS := mt7981b-wirelesstag-zx7981pd
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware kmod-usb3 mt7981-wo-firmware
+  DEVICE_DTS_LOADADDR := 0x44000000
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 51200k
+  KERNEL_IN_UBI := 1
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += wirelesstag_zx7981pd


### PR DESCRIPTION
https://shop.wireless-tag.com/products/wt7981pc-global-wt7981pc-5g-wifi-router-wifi6-router-built-in-4-5g-lte-antennas-and-5-wifi-antennas-dual-core-a53-1-3ghz-5g-module

the label under the modem is ZX7981PD