### PR TITLE
将5.4内核Wi-Fi信号的图标改为svg格式

### DIFF
--- a/package/mtk/applications/luci-app-mtwifi-cfg/root/usr/share/luci-app-mtwifi-cfg/wireless-mtk.js
+++ b/package/mtk/applications/luci-app-mtwifi-cfg/root/usr/share/luci-app-mtwifi-cfg/wireless-mtk.js
@@ -28,7 +28,7 @@ function count_changes(section_id) {
 
 function render_radio_badge(radioDev) {
 	return E('span', { 'class': 'ifacebadge' }, [
-		E('img', { 'src': L.resource('icons/wifi%s.png').format(radioDev.isUp() ? '' : '_disabled') }),
+		E('img', { 'src': L.resource('icons/wifi%s.svg').format(radioDev.isUp() ? '' : '_disabled') }),
 		' ',
 		radioDev.getName()
 	]);
@@ -38,17 +38,17 @@ function render_signal_badge(signalPercent, signalValue, noiseValue, wrap, mode)
 	var icon, title, value;
 
 	if (signalPercent < 0)
-		icon = L.resource('icons/signal-none.png');
+		icon = L.resource('icons/signal-none.svg');
 	else if (signalPercent == 0)
-		icon = L.resource('icons/signal-0.png');
+		icon = L.resource('icons/signal-000-000.svg');
 	else if (signalPercent < 25)
-		icon = L.resource('icons/signal-0-25.png');
+		icon = L.resource('icons/signal-000-025.svg');
 	else if (signalPercent < 50)
-		icon = L.resource('icons/signal-25-50.png');
+		icon = L.resource('icons/signal-025-050.svg');
 	else if (signalPercent < 75)
-		icon = L.resource('icons/signal-50-75.png');
+		icon = L.resource('icons/signal-050-075.svg');
 	else
-		icon = L.resource('icons/signal-75-100.png');
+		icon = L.resource('icons/signal-075-100.svg');
 
 	if (signalValue != null && signalValue != 0) {
 		if (noiseValue != null && noiseValue != 0) {
@@ -707,7 +707,7 @@ return view.extend({
 					'data-ssid': bss.network.getSSID()
 				}, [
 					E('img', {
-						'src': L.resource('icons/wifi%s.png').format(bss.network.isUp() ? '' : '_disabled'),
+						'src': L.resource('icons/wifi%s.svg').format(bss.network.isUp() ? '' : '_disabled'),
 						'title': bss.radio.getI18n()
 					}),
 					E('span', [


### PR DESCRIPTION
现在用png格式编译wifi信号图标会显示不出来，6.6内核已经修复了，这里把5.4内核的也改成新的。