### PR TITLE
package: iwinfo: close fd before return

### DIFF
--- a/package/network/utils/iwinfo/patches/0001-support-mt798x.patch
+++ b/package/network/utils/iwinfo/patches/0001-support-mt798x.patch
@@ -227,7 +227,7 @@
 +		}
 +	}
 +	lseek(fd, 0, SEEK_SET);
-+ return 0;
++ close(fd); return 0;
  	bc = mmap(NULL, len, PROT_READ, MAP_PRIVATE|MAP_LOCKED, fd, 0);
  
  	if ((void *)bc != MAP_FAILED)


### PR DESCRIPTION
修复文件描述符耗尽的ERROR （No file descriptors available）