### PR TITLE
mediatek: add AKM24 AKM25 support

### DIFF
--- a/package/mtk/applications/luci-app-mtwifi-cfg/root/usr/share/luci-app-mtwifi-cfg/wireless-mtk.js
+++ b/package/mtk/applications/luci-app-mtwifi-cfg/root/usr/share/luci-app-mtwifi-cfg/wireless-mtk.js
@@ -1604,16 +1604,18 @@ return view.extend({
 					crypto_modes.push(['wep-shared', _('WEP Shared Key'),         10]);
 				}
 				else if (hwtype == 'mtwifi') {
-					if (band == '6g') {
+/* add support AKM24 WPA3-SAE-EXT */
+					crypto_modes.push(['sae-ext-mixed',     'WPA2-PSK/WPA3-SAE/WPA3-SAE_EXT Mixed Mode', ??]);
+					crypto_modes.push(['sae_sae-ext', 'WPA3-SAE/WPA3-SAE_EXT',                     ??]);
+					crypto_modes.push(['sae-ext',      'WPA3-SAE_EXT',                     ??]);
+/* add support AKM24 WPA3-SAE-EXT */
 					crypto_modes.push(['sae', 'WPA3-SAE', 31]);
-					}
 					crypto_modes.push(['owe', 'OWE', 1]);
 					if (band != '6g') {
 						crypto_modes.push(['psk2', 'WPA2-PSK', 35]);
 						crypto_modes.push(['psk', 'WPA-PSK', 12]);
-						if (ifmode == 'ap') {
-							crypto_modes.push(['psk-mixed', 'WPA-PSK/WPA2-PSK Mixed Mode', 22]);
-						}
+						crypto_modes.push(['psk-mixed', 'WPA-PSK/WPA2-PSK Mixed Mode', 22]);
+						crypto_modes.push(['sae-mixed', 'WPA2-PSK/WPA3-SAE Mixed Mode', 36]);
 					}
 				}
 
@@ -1683,6 +1685,11 @@ return view.extend({
 				o.depends('encryption', 'psk-mixed');
 				o.depends('encryption', 'sae');
 				o.depends('encryption', 'sae-mixed');
+/* add support AKM24 WPA3-SAE-EXT */
+				o.depends('encryption', 'sae-ext');
+				o.depends('encryption', 'sae_sae-ext');
+				o.depends('encryption', 'sae-ext-mixed');
+/* add support AKM24 WPA3-SAE-EXT */
 				o.datatype = 'wpakey';
 				o.rmempty = true;
 				o.password = true;

--- a/package/mtk/applications/mtwifi-cfg/files/mtwifi-cfg/mtwifi_defs.lua
+++ b/package/mtk/applications/mtwifi-cfg/files/mtwifi-cfg/mtwifi_defs.lua
@@ -104,7 +104,11 @@ mtwifi_defs.enc2dat = {
     -- enc = AuthMode, EncrypType
     ["none"] = {"OPEN", "NONE"},
     ["sae"] = {"WPA3PSK", "AES"},
-    ["sae-mixed"] = {"WPA2PSKWPA3PSK", "AES"},
+    -- /* add support AKM24 WPA3-SAE-EXT */
+    ["sae-ext"] = {"WPA3PSK-EXT", "GCMP256"},
+    ["sae_sae-ext"] = {"WPA3PSKWPA3PSK-EXT", "CCMP GCMP256"},
+    ["sae-ext-mixed"] = {"WPA2PSKWPA3PSKWPA3PSK-EXT", "CCMP GCMP256"},
+    -- /* add support AKM24 WPA3-SAE-EXT */
     ["psk2+tkip+ccmp"] = {"WPA2PSK", "TKIPAES"},
     ["psk2+tkip+aes"] = {"WPA2PSK", "TKIPAES"},
     ["psk2+tkip"] = {"WPA2PSK", "TKIP"},

--- a/package/mtk/drivers/mt_hwifi/src/mt_wifi/common/security/cmm_sec.c
+++ b/package/mtk/drivers/mt_hwifi/src/mt_wifi/common/security/cmm_sec.c
@@ -297,7 +297,7 @@ VOID SetWdevAuthMode(
 #if defined(DOT11_SAE_SUPPORT) || defined(SUPP_SAE_SUPPORT)
 	else if (rtstrcasecmp(arg, "WPA3PSK") == TRUE)
 		SET_AKM_SAE_SHA256(AKMMap);
-	else if (rtstrcasecmp(arg, "WPA3PSK_EXT") == TRUE) {
+	else if (rtstrcasecmp(arg, "WPA3PSK-EXT") == TRUE) {
 		SET_AKM_SAE_EXT(AKMMap);
 	} else if (rtstrcasecmp(arg, "WPA2PSKWPA3PSK") == TRUE) {
 		SET_AKM_SAE_SHA256(AKMMap);
@@ -306,6 +306,13 @@ VOID SetWdevAuthMode(
 		SET_AKM_SAE_SHA256(AKMMap);
 		SET_AKM_WPA2PSK(AKMMap);
 		SET_AKM_WPA2PSK_SHA256(AKMMap);
+	} else if (rtstrcasecmp(arg, "WPA3PSKWPA3PSK-EXT") == TRUE) {
+		SET_AKM_SAE_SHA256(AKMMap);
+		SET_AKM_SAE_EXT(AKMMap);
+	} else if (rtstrcasecmp(arg, "WPA2PSKWPA3PSKWPA3PSK-EXT") == TRUE) {
+		SET_AKM_SAE_SHA256(AKMMap);
+		SET_AKM_WPA2PSK(AKMMap);
+		SET_AKM_SAE_EXT(AKMMap);
 	}
 #endif /* DOT11_SAE_SUPPORT */
 	else if (rtstrcasecmp(arg, "WPA1WPA2") == TRUE) {
@@ -362,7 +369,7 @@ VOID SetWdevAuthMode(
 		SET_AKM_SAE_SHA256(AKMMap);
 		SET_AKM_SAE_EXT(AKMMap);
 	} else if (rtstrcasecmp(arg, "SAE-EXTWPA2PSK") == TRUE) {
-		SET_AKM_DPP(AKMMap);
+		SET_AKM_SAE_EXT(AKMMap);
 		SET_AKM_WPA2PSK(AKMMap);
 	} else if (rtstrcasecmp(arg, "SAE-EXTWPA3PSK") == TRUE) {
 		SET_AKM_SAE_SHA256(AKMMap);
@@ -714,6 +721,8 @@ RTMP_STRING *GetAuthModeStr(
 		return "DPPWPA3PSK";
 	else if (IS_AKM_WPA2PSK(authMode) && IS_AKM_DPP(authMode))
 		return "DPPWPA2PSK";
+	else if (IS_AKM_SAE_SHA256(authMode) && IS_AKM_SAE_EXT(authMode))
+		return "WPA3PSKWPA3PSK-EXT";
 	else if (IS_AKM_WPA2PSK(authMode) && IS_AKM_SAE_SHA256(authMode) && IS_AKM_SAE_EXT(authMode))
 		return "WPA2PSKWPA3PSKWPA3PSK-EXT";
 	else if (IS_AKM_WPA2PSK(authMode) && IS_AKM_SAE_SHA256(authMode))

--- a/package/mtk/drivers/mt_wifi7/src/mt_wifi/common/security/cmm_sec.c
+++ b/package/mtk/drivers/mt_wifi7/src/mt_wifi/common/security/cmm_sec.c
@@ -297,7 +297,7 @@ VOID SetWdevAuthMode(
 #if defined(DOT11_SAE_SUPPORT) || defined(SUPP_SAE_SUPPORT)
 	else if (rtstrcasecmp(arg, "WPA3PSK") == TRUE)
 		SET_AKM_SAE_SHA256(AKMMap);
-	else if (rtstrcasecmp(arg, "WPA3PSK_EXT") == TRUE) {
+	else if (rtstrcasecmp(arg, "WPA3PSK-EXT") == TRUE) {
 		SET_AKM_SAE_EXT(AKMMap);
 	} else if (rtstrcasecmp(arg, "WPA2PSKWPA3PSK") == TRUE) {
 		SET_AKM_SAE_SHA256(AKMMap);
@@ -306,6 +306,13 @@ VOID SetWdevAuthMode(
 		SET_AKM_SAE_SHA256(AKMMap);
 		SET_AKM_WPA2PSK(AKMMap);
 		SET_AKM_WPA2PSK_SHA256(AKMMap);
+	} else if (rtstrcasecmp(arg, "WPA3PSKWPA3PSK-EXT") == TRUE) {
+		SET_AKM_SAE_SHA256(AKMMap);
+		SET_AKM_SAE_EXT(AKMMap);
+	} else if (rtstrcasecmp(arg, "WPA2PSKWPA3PSKWPA3PSK-EXT") == TRUE) {
+		SET_AKM_SAE_SHA256(AKMMap);
+		SET_AKM_WPA2PSK(AKMMap);
+		SET_AKM_SAE_EXT(AKMMap);
 	}
 #endif /* DOT11_SAE_SUPPORT */
 	else if (rtstrcasecmp(arg, "WPA1WPA2") == TRUE) {
@@ -362,7 +369,7 @@ VOID SetWdevAuthMode(
 		SET_AKM_SAE_SHA256(AKMMap);
 		SET_AKM_SAE_EXT(AKMMap);
 	} else if (rtstrcasecmp(arg, "SAE-EXTWPA2PSK") == TRUE) {
-		SET_AKM_DPP(AKMMap);
+		SET_AKM_SAE_EXT(AKMMap);
 		SET_AKM_WPA2PSK(AKMMap);
 	} else if (rtstrcasecmp(arg, "SAE-EXTWPA3PSK") == TRUE) {
 		SET_AKM_SAE_SHA256(AKMMap);
@@ -714,6 +721,8 @@ RTMP_STRING *GetAuthModeStr(
 		return "DPPWPA3PSK";
 	else if (IS_AKM_WPA2PSK(authMode) && IS_AKM_DPP(authMode))
 		return "DPPWPA2PSK";
+	else if (IS_AKM_SAE_SHA256(authMode) && IS_AKM_SAE_EXT(authMode))
+		return "WPA3PSKWPA3PSK-EXT";
 	else if (IS_AKM_WPA2PSK(authMode) && IS_AKM_SAE_SHA256(authMode) && IS_AKM_SAE_EXT(authMode))
 		return "WPA2PSKWPA3PSKWPA3PSK-EXT";
 	else if (IS_AKM_WPA2PSK(authMode) && IS_AKM_SAE_SHA256(authMode))

--- a/package/network/config/netifd/patches/002-add-akm24-support.patch
+++ b/package/network/config/netifd/patches/002-add-akm24-support.patch
@@ -1,0 +1,87 @@
+--- a/scripts/netifd-wireless.sh
++++ b/scripts/netifd-wireless.sh
+@@ -204,6 +204,43 @@ _wdev_wrapper \
+ 	wireless_process_kill_all \
+ 	wireless_set_retry \
+ 
++wireless_vif_parse_encryption_rsno() {
++	json_get_vars encryption_rsno encryption_rsno_2
++	set_default encryption_rsno none
++	set_default encryption_rsno_2 none
++
++	rsno_auth_type=none
++	rsno_auth_type_2=none
++	rsno_wpa_cipher="CCMP"
++	rsno_wpa_cipher_2="GCMP-256"
++
++	case "$encryption_rsno" in
++		*ccmp256) rsno_wpa_cipher="CCMP-256";;
++		*aes|*ccmp) rsno_wpa_cipher="CCMP";;
++		*gcmp256) rsno_wpa_cipher="GCMP-256";;
++		*gcmp) rsno_wpa_cipher="GCMP";;
++	esac
++
++	case "$encryption_rsno_2" in
++		*ccmp256) rsno_wpa_cipher_2="CCMP-256";;
++		*aes|*ccmp) rsno_wpa_cipher_2="CCMP";;
++		*gcmp256) rsno_wpa_cipher_2="GCMP-256";;
++		*gcmp) rsno_wpa_cipher_2="GCMP";;
++	esac
++
++	case "$encryption_rsno" in
++		psk3*|sae*)
++			rsno_auth_type=sae
++		;;
++	esac
++
++	case "$encryption_rsno_2" in
++		psk3*|sae*)
++			rsno_auth_type_2=sae
++		;;
++	esac
++}
++
+ wireless_vif_parse_encryption() {
+ 	json_get_vars encryption
+ 	set_default encryption none
+@@ -214,6 +251,10 @@ wireless_vif_parse_encryption() {
+ 
+ 	if [ "$hwmode" = "ad" ]; then
+ 		wpa_cipher="GCMP"
++	elif [ "$_w_mode" = "sta" ]; then
++		wpa_cipher="CCMP CCMP-256 GCMP GCMP-256"
++	elif [ "$encryption" == "sae-ext" ] ;then
++		wpa_cipher="GCMP-256"
+ 	else
+ 		wpa_cipher="CCMP"
+ 	fi
+@@ -223,6 +264,8 @@ wireless_vif_parse_encryption() {
+ 		*gcmp256) wpa_cipher="GCMP-256";;
+ 		*gcmp) wpa_cipher="GCMP";;
+ 		wpa3-192*) wpa_cipher="GCMP-256";;
++		sae_sae-ext) wpa_cipher="CCMP GCMP-256";;
++		sae-ext-mixed) wpa_cipher="CCMP GCMP-256";;
+ 	esac
+ 
+ 	# 802.11n requires CCMP for WPA
+@@ -269,6 +311,12 @@ wireless_vif_parse_encryption() {
+ 		psk3-mixed*|sae-mixed*)
+ 			auth_type=psk-sae
+ 		;;
++		sae-ext)
++			auth_type=sae-ext
++		;;
++		sae-ext-mixed*)
++			auth_type=psk-sae-ext
++		;;
+ 		psk3*|sae*)
+ 			auth_type=sae
+ 		;;
+@@ -378,6 +427,7 @@ _wdev_common_iface_config() {
+ 
+ _wdev_common_iface_config() {
+ 	config_add_string mode ssid encryption 'key:wpakey'
++	config_add_string encryption_rsno encryption_rsno_2
+ 	config_add_boolean bridge_isolate
+ 	config_add_array tags
+ }

--- a/package/network/utils/iwinfo/patches/0002-support-akm24-wpa3-sae-ext.patch
+++ b/package/network/utils/iwinfo/patches/0002-support-akm24-wpa3-sae-ext.patch
@@ -1,0 +1,79 @@
+--- a/include/iwinfo.h
++++ b/include/iwinfo.h
+@@ -104,18 +104,21 @@ enum iwinfo_kmgmt {
+ 	IWINFO_KMGMT_8021x,
+ 	IWINFO_KMGMT_PSK,
+ 	IWINFO_KMGMT_SAE,
++	IWINFO_KMGMT_SAE_EXT,
+ 	IWINFO_KMGMT_OWE,
+ 
+ 	/* keep last */
+ 	IWINFO_KMGMT_COUNT
+ };
+ 
+ #define IWINFO_KMGMT_NONE    (1 << IWINFO_KMGMT_NONE)
+ #define IWINFO_KMGMT_8021x   (1 << IWINFO_KMGMT_8021x)
+ #define IWINFO_KMGMT_PSK     (1 << IWINFO_KMGMT_PSK)
+-#define IWINFO_KMGMT_SAE     (1 << IWINFO_KMGMT_SAE)
++#define IWINFO_KMGMT_SAE     (1 << IWINFO_KMGMT_SAE) | (1 << IWINFO_KMGMT_SAE_EXT)
+ #define IWINFO_KMGMT_OWE     (1 << IWINFO_KMGMT_OWE)
+ 
++#define IWINFO_KMGMT_SAE_EXT (1 << IWINFO_KMGMT_SAE_EXT)
++
+ extern const char * const IWINFO_KMGMT_NAMES[IWINFO_KMGMT_COUNT];
+ 
+ 
+--- a/iwinfo_lib.c
++++ b/iwinfo_lib.c
+@@ -59,6 +59,7 @@ const char * const IWINFO_KMGMT_NAMES[I
+ 	"802.1X",
+ 	"PSK",
+ 	"SAE",
++	"SAE_EXT",
+ 	"OWE",
+ };
+ 
+--- a/iwinfo_lua.c
++++ b/iwinfo_lua.c
+@@ -92,14 +92,20 @@ static char * iwinfo_crypto_print_suites(int
+ 	static char str[64] = { 0 };
+ 	char *pos = str;
+ 
++	if (suites & IWINFO_KMGMT_SAE) {
++		pos += sprintf(pos, "SAE");
++		if (suites & IWINFO_KMGMT_SAE_EXT) {
++			pos += sprintf(pos, "/SAE_EXT");
++		}
++		pos += sprintf(pos, "/");
++	}
++
+ 	if (suites & IWINFO_KMGMT_PSK)
+ 		pos += sprintf(pos, "PSK/");
+ 
+ 	if (suites & IWINFO_KMGMT_8021x)
+ 		pos += sprintf(pos, "802.1X/");
+ 
+-	if (suites & IWINFO_KMGMT_SAE)
+-		pos += sprintf(pos, "SAE/");
+ 
+ 	if (suites & IWINFO_KMGMT_OWE)
+ 		pos += sprintf(pos, "OWE/");
+--- a/iwinfo_utils.c
++++ b/iwinfo_utils.c
+@@ -601,12 +601,16 @@ void iwinfo_parse_rsn(struct
+ 					break;
+ 
+ 				case 8:  /* SAE */
++				case 24: /* SAE_EXT */
+ 					c->wpa_version |= 4;
+ 					c->auth_suites |= IWINFO_KMGMT_SAE;
++					if (data[2 + (i * 4) + 3] == 24)
++						c->auth_suites |= IWINFO_KMGMT_SAE_EXT;
+ 					break;
+ 
+ 				case 9:  /* FT/SAE */
+ 				case 10: /* undefined */
++				case 25: /* FT/SAE_EXT */
+ 					break;
+ 
+ 				case 11: /* 802.1x Suite-B */

--- a/package/network/utils/iwinfo/src/iwinfo_mtk.c
+++ b/package/network/utils/iwinfo/src/iwinfo_mtk.c
@@ -902,6 +902,11 @@ static int mtk_get_encryption(const char *dev, char *buf)
 		if (IS_AKM_FT_SAE_SHA256(authMode) || IS_AKM_SAE_SHA256(authMode))
 			c->auth_suites |= IWINFO_KMGMT_SAE;
 
+		/* add support AKM24 WPA3-SAE-EXT */
+		if (IS_AKM_SAE_EXT(authMode) || IS_AKM_FT_SAE_EXT(authMode))
+			c->auth_suites |= IWINFO_KMGMT_SAE_EXT;
+		/* add support AKM24 WPA3-SAE-EXT */
+
 		if (IS_AKM_OWE(authMode))
 			c->auth_suites |= IWINFO_KMGMT_OWE;
 

--- a/package/network/utils/iwinfo/src/mtwifi.h
+++ b/package/network/utils/iwinfo/src/mtwifi.h
@@ -252,6 +252,10 @@ typedef enum _SEC_AKM_MODE {
 	SEC_AKM_FILS_SHA256,
 	SEC_AKM_FILS_SHA384,
 	SEC_AKM_WPA3, /* WPA3(ent) = WPA2(ent) + PMF MFPR=1 => WPA3 code flow is same as WPA2, the usage of SEC_AKM_WPA3 is to force pmf on */
+	/* add support AKM24 WPA3-SAE-EXT */
+	SEC_AKM_SAE_EXT,
+	SEC_AKM_FT_SAE_EXT,
+	/* add support AKM24 WPA3-SAE-EXT */
 	SEC_AKM_MAX /* Not a real mode, defined as upper bound */
 } SEC_AKM_MODE;
 
@@ -274,9 +278,14 @@ typedef enum _SEC_AKM_MODE {
 #define IS_AKM_SUITEB_SHA384(_AKMMap)          ((_AKMMap & (1 << SEC_AKM_SUITEB_SHA384)) > 0)
 #define IS_AKM_FT_WPA2_SHA384(_AKMMap)      ((_AKMMap & (1 << SEC_AKM_FT_WPA2_SHA384)) > 0)
 #define IS_AKM_WPA3(_AKMMap)	 ((_AKMMap & (1 << SEC_AKM_WPA3)) > 0)
-#define IS_AKM_WPA3PSK(_AKMMap) (IS_AKM_SAE_SHA256(_AKMMap))
 #define IS_AKM_WPA3_192BIT(_AKMMap)	(IS_AKM_SUITEB_SHA384(_AKMMap))
 #define IS_AKM_OWE(_AKMMap) ((_AKMMap & (1 << SEC_AKM_OWE)) > 0)
+/* add support AKM24 WPA3-SAE-EXT */
+#define IS_AKM_SAE_EXT(_AKMMap)                ((_AKMMap & (1 << SEC_AKM_SAE_EXT)) > 0)
+#define IS_AKM_FT_SAE_EXT(_AKMMap)          ((_AKMMap & (1 << SEC_AKM_FT_SAE_EXT)) > 0)
+#define IS_AKM_WPA3PSK(_AKMMap) (IS_AKM_SAE_SHA256(_AKMMap) \
+									|| IS_AKM_SAE_EXT(_AKMMap))
+/* add support AKM24 WPA3-SAE-EXT */
 
 #define MTK_L1_PROFILE_PATH		"/etc/wireless/l1profile.dat"
 #define MTK_L1UTIL_PATH			"/usr/lib/lua/l1dat_parser.lua"


### PR DESCRIPTION
With the support of 80211BE by mtw_ifi, AKM24, AKM25 encryption mode and MLO have been introduced, but currently they are not very complete, and the driver and LUCI cannot be coordinated. We look forward to everyone working together to improve it!

Signed-off-by: nanchuci <nanchuci023@gmail.com>