### PR TITLE
hnat: reduce kernel log verbosity of ppd_dev_setting()

### DIFF
--- a/target/linux/mediatek/files-6.6/drivers/net/ethernet/mediatek/mtk_hnat/hnat_nf_hook.c
+++ b/target/linux/mediatek/files-6.6/drivers/net/ethernet/mediatek/mtk_hnat/hnat_nf_hook.c
@@ -389,8 +389,9 @@ void ppd_dev_setting(void)
 			}
 		}
 	}
-        printk("\nrx now ppd dev is %s\n",hnat_priv->g_ppdev->name);
-        printk("\ntx now ppd dev is %s\n",ppd_dev->name);
+	
+	pr_info("%s : now rx dev: %s, tx dev: %s\n", 
+		__func__, hnat_priv->g_ppdev->name, ppd_dev->name);
 }
 
 int nf_hnat_netdevice_event(struct notifier_block *unused, unsigned long event,


### PR DESCRIPTION
- since `printk()` is used twice, taking up 4 lines in every function call, we squash it into single `pr_info()` call and get rid of `\n`'s to reduce verbosity.