### PR TITLE
iwinfo: mtk_get_freqlist Remove the unnecessary wext_freq2x

### DIFF
--- a/package/network/utils/iwinfo/src/iwinfo_mtk.c
+++ b/package/network/utils/iwinfo/src/iwinfo_mtk.c
@@ -588,26 +588,6 @@ static int mtk_get_scanlist(const char *dev, char *buf, int *len)
 	return 0;
 }
 
-static double wext_freq2float(const struct iw_freq *in)
-{
-	int		i;
-	double	res = (double) in->m;
-	for(i = 0; i < in->e; i++) res *= 10;
-	return res;
-}
-
-static inline int wext_freq2mhz(const struct iw_freq *in)
-{
-	if( in->e == 6 )
-	{
-		return in->m;
-	}
-	else
-	{
-		return (int)(wext_freq2float(in) / 1000000);
-	}
-}
-
 static int mtk_get_freqlist(const char *dev, char *buf, int *len)
 {
 	struct iwreq wrq;
@@ -633,7 +613,7 @@ static int mtk_get_freqlist(const char *dev, char *buf, int *len)
 
 		for (i = 0; i < range.num_frequency; i++)
 		{
-			entry.mhz        = wext_freq2mhz(&range.freq[i]);
+			entry.mhz        = range.freq[i].m;
 			entry.channel    = range.freq[i].i;
 			entry.restricted = 0;
 


### PR DESCRIPTION
在ap_ioctl里channel_to_frequency获取的已是mhz，不再需要wext_freq2mhz来转换了！