### PR TITLE
luci-app-mtwifi-cfg: use luci-24.10 mod-status(BE)

### DIFF
--- a/package/mtk/applications/luci-app-mtwifi-cfg/root/usr/share/luci-app-mtwifi-cfg/luci-mod-status.json
+++ b/package/mtk/applications/luci-app-mtwifi-cfg/root/usr/share/luci-app-mtwifi-cfg/luci-mod-status.json
@@ -11,27 +11,51 @@
 		}
 	},
 
-	"admin/status/iptables": {
-		"title": "Firewall",
-		"order": 2,
-		"action": {
-			"type": "view",
-			"path": "status/iptables"
-		},
-		"depends": {
-			"acl": [ "luci-mod-status-firewall" ]
-		}
-	},
-
 	"admin/status/routes": {
-		"title": "Routes",
-		"order": 3,
+		"title": "Routing",
+		"order": 2,
 		"action": {
 			"type": "view",
 			"path": "status/routes"
 		},
 		"depends": {
 			"acl": [ "luci-mod-status-routes" ]
+		}
+	},
+
+	"admin/status/iptables": {
+		"title": "Firewall",
+		"order": 3,
+		"action": {
+			"type": "view",
+			"path": "status/iptables"
+		},
+		"depends": {
+			"acl": [ "luci-mod-status-firewall" ],
+			"fs": [
+				{ "/usr/sbin/nft": "absent", "/usr/sbin/iptables": "executable" },
+				{ "/usr/sbin/nft": "absent", "/usr/sbin/ip6tables": "executable" }
+			]
+		}
+	},
+
+	"admin/status/nftables": {
+		"title": "Firewall",
+		"order": 3,
+		"action": {
+			"type": "view",
+			"path": "status/nftables"
+		},
+		"depends": {
+			"acl": [ "luci-mod-status-firewall" ],
+			"fs": { "/usr/sbin/nft": "executable" }
+		}
+	},
+
+	"admin/status/nftables/iptables": {
+		"action": {
+			"type": "view",
+			"path": "status/iptables"
 		}
 	},
 
@@ -112,7 +136,7 @@
 	},
 
 	"admin/status/realtime/bandwidth": {
-		"title": "Traffic",
+		"title": "Bandwidth",
 		"order": 2,
 		"action": {
 			"type": "view",


### PR DESCRIPTION
1.修复中文语言，状态页下显示“Routes”问题。
2.因使用WIFI连接，mt_wifi驱动在信道分析页面调用SiteSurvey会造成WiFi断连的问题，所以继续屏蔽掉mtwifi的信道分析功能（只保留mac80211）。