### PR TITLE
iwinfo: fix kernel warning when accessing NAND partitions

### DIFF
--- a/package/network/utils/iwinfo/patches/0002-use-char-device-to-read.patch
+++ b/package/network/utils/iwinfo/patches/0002-use-char-device-to-read.patch
@@ -1,0 +1,11 @@
+--- a/iwinfo_utils.c
++++ b/iwinfo_utils.c
+@@ -367,7 +367,7 @@ int iwinfo_hardware_id_from_mtd(struct i
+ 	if (off < 0)
+ 		return -1;
+ 
+-	snprintf(buf, sizeof(buf), "/dev/mtdblock%d", off);
++	snprintf(buf, sizeof(buf), "/dev/mtd%d", off);
+ 
+ 	if ((fd = open(buf, O_RDONLY)) < 0)
+ 		return -1;

--- a/target/linux/mediatek/patches-6.6/9998-mtk_enhance.patch
+++ b/target/linux/mediatek/patches-6.6/9998-mtk_enhance.patch
@@ -41,30 +41,3 @@
  		skb_record_rx_queue(skb, 0);
  		napi_gro_receive(napi, skb);
  
-
---- a/drivers/mtd/mtdblock_ro.c
-+++ b/drivers/mtd/mtdblock_ro.c
-@@ -48,10 +48,6 @@
- 	dev->tr = tr;
- 	dev->readonly = 1;
- 
--	if (mtd_type_is_nand(mtd))
--		pr_warn_ratelimited("%s: MTD device '%s' is NAND, please consider using UBI block devices instead.\n",
--			tr->name, mtd->name);
--
- 	if (add_mtd_blktrans_dev(dev))
- 		kfree(dev);
- }
---- a/drivers/mtd/mtdblock.c
-+++ b/drivers/mtd/mtdblock.c
-@@ -261,10 +261,6 @@
- 		return 0;
- 	}
- 
--	if (mtd_type_is_nand(mbd->mtd))
--		pr_warn_ratelimited("%s: MTD device '%s' is NAND, please consider using UBI block devices instead.\n",
--			mbd->tr->name, mbd->mtd->name);
--
- 	/* OK, it's not open. Create cache info for it */
- 	mtdblk->count = 1;
- 	mutex_init(&mtdblk->cache_mutex);


### PR DESCRIPTION
The current implementation constructs a "/dev/mtdblockX" path to read the 'Factory' partition, triggering kernel warnings. Using "/dev/mtdX" can fix that.

This commit removes patch to suppress kernel warnings, and adds a patch to iwinfo to read char device instead of block device.