### PR TITLE
mediatek: filogic: add MTK U-Boot layout variant for Xiaomi AX3000T

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -152,6 +152,7 @@ ubnt,unifi-6-plus)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x10000"
 	;;
 xiaomi,mi-router-ax3000t|\
+xiaomi,mi-router-ax3000t-mtkuboot|\
 xiaomi,mi-router-wr30u-stock|\
 xiaomi,mi-router-wr30u-ubootmod|\
 xiaomi,redmi-router-ax6000-stock)

--- a/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
+++ b/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
@@ -26,6 +26,7 @@ set_preinit_iface() {
 		ifname=lan
 		;;
 	xiaomi,mi-router-ax3000t|\
+	xiaomi,mi-router-ax3000t-mtkuboot|\
 	xiaomi,mi-router-ax3000t-ubootmod|\
 	xiaomi,mi-router-wr30u-stock|\
 	xiaomi,mi-router-wr30u-ubootmod|\

--- a/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-ax3000t-mtkuboot.dts
+++ b/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-ax3000t-mtkuboot.dts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include "mt7981b-xiaomi-mi-router-ax3000t.dtsi"
+
+/ {
+	model = "Xiaomi Mi Router AX3000T (MTK U-Boot layout)";
+	compatible = "xiaomi,mi-router-ax3000t-mtkuboot", "mediatek,mt7981";
+};
+
+&spi_nand {
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+	mediatek,bmt-mtd-overridden-oobsize = <64>;
+};
+
+&partitions {
+	partition@600000 {
+		label = "ubi";
+		reg = <0x600000 0x7000000>;
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -155,6 +155,7 @@ mediatek_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan1 lan2" wan
 		;;
 	xiaomi,mi-router-ax3000t|\
+	xiaomi,mi-router-ax3000t-mtkuboot|\
 	xiaomi,mi-router-ax3000t-ubootmod|\
 	xiaomi,mi-router-wr30u-stock|\
 	xiaomi,mi-router-wr30u-ubootmod|\
@@ -236,6 +237,7 @@ mediatek_setup_macs()
  		label_mac=$lan_mac
  		;;
 	xiaomi,mi-router-ax3000t|\
+	xiaomi,mi-router-ax3000t-mtkuboot|\
 	xiaomi,mi-router-ax3000t-ubootmod|\
 	xiaomi,mi-router-wr30u-stock|\
 	xiaomi,mi-router-wr30u-ubootmod|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1994,6 +1994,23 @@ endif
 endef
 TARGET_DEVICES += xiaomi_mi-router-ax3000t
 
+define Device/xiaomi_mi-router-ax3000t-mtkuboot
+  DEVICE_VENDOR := Xiaomi
+  DEVICE_MODEL := Mi Router AX3000T
+  DEVICE_VARIANT := (MTK U-Boot layout)
+  DEVICE_DTS := mt7981b-xiaomi-mi-router-ax3000t-mtkuboot
+  DEVICE_DTS_DIR := ../dts
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 114688k
+  KERNEL_IN_UBI := 1
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += xiaomi_mi-router-ax3000t-mtkuboot
+
 define Device/xiaomi_mi-router-ax3000t-ubootmod
   DEVICE_VENDOR := Xiaomi
   DEVICE_MODEL := Mi Router AX3000T


### PR DESCRIPTION
- this adds mtk uboot expand layout support for Xiaomi AX3000T Note:
1. use mtk uboot with expand layout to flash
2. DO NOT sysupgrade to -stock (with no suffix) or -ubootmod version