### PR TITLE
mediatek: Fixed WNM(80211v) always being on(BE)

### DIFF
--- a/package/mtk/applications/luci-app-mtwifi-cfg/root/usr/share/luci-app-mtwifi-cfg/wireless-mtk.js
+++ b/package/mtk/applications/luci-app-mtwifi-cfg/root/usr/share/luci-app-mtwifi-cfg/wireless-mtk.js
@@ -1353,6 +1353,10 @@ return view.extend({
 					o.default = o.enabled;
 					o.depends('mode', 'ap');
 
+					o = ss.taboption('advanced', form.Flag, 'bss_transition', _('BSS Transition'), _('802.11v: Basic Service Set (BSS) transition management.'));
+					o.depends('mode', 'ap');
+					o.rmempty = true;
+
 					o = ss.taboption('advanced', form.Value, 'wpa_group_rekey', _('Time interval for rekeying GTK'), _('sec'));
 					o.optional    = true;
 					o.placeholder = 3600;

--- a/package/mtk/applications/mtwifi-cfg/files/mtwifi-cfg/mtwifi_cfg
+++ b/package/mtk/applications/mtwifi-cfg/files/mtwifi-cfg/mtwifi_cfg
@@ -618,6 +618,7 @@ end
             set_dat(dats, apidx, "FragThreshold",v.config.frag)
             set_dat(dats, apidx, "DtimPeriod",v.config.dtim_period)
             set_dat(dats, apidx, "WirelessMode", WirelessMode)
+            set_dat(dats, apidx, "WNMEnable", v.config.bss_transition)
 
             if is_be_mode(cfg) then
                 set_dat(dats, apidx, "PpMuMimoDlEnable", not v.config.mumimo_dl and 0 or 1)

--- a/package/mtk/applications/mtwifi-cfg/files/mtwifi-cfg/mtwifi_defs.lua
+++ b/package/mtk/applications/mtwifi-cfg/files/mtwifi-cfg/mtwifi_defs.lua
@@ -57,6 +57,7 @@ mtwifi_defs.vif_cfgs = {
     ["HT_STBC"] = "1",
     ["IgmpSnEnable"] = "0",
     ["RRMEnable"] = "1",
+    ["WNMEnable"] = "0",
     ["VHT_BW_SIGNAL"] = "0",
     ["VHT_LDPC"] = "1",
     ["VHT_SGI"] = "1",

--- a/package/mtk/applications/mtwifi-cfg/files/netifd/mtwifi.sh
+++ b/package/mtk/applications/mtwifi-cfg/files/netifd/mtwifi.sh
@@ -21,7 +21,7 @@ drv_mtwifi_init_device_config() {
 
 drv_mtwifi_init_iface_config() {
 	config_add_string 'ssid:string' macfilter bssid kicklow assocthres 'macaddr:macaddr'
-	config_add_boolean mlo wmm hidden isolate ieee80211k
+	config_add_boolean mlo wmm hidden isolate ieee80211k bss_transition
 	config_add_int wpa_group_rekey frag rts dtim_period
 	config_add_array 'maclist:list(macaddr)'
 	config_add_boolean mumimo_dl mumimo_ul ofdma_dl ofdma_ul amsdu autoba uapsd

--- a/package/mtk/drivers/mt_hwifi/src/mt_wifi/feature/hs_r2/hotspot.c
+++ b/package/mtk/drivers/mt_hwifi/src/mt_wifi/feature/hs_r2/hotspot.c
@@ -811,6 +811,7 @@ static VOID HSCtrlOff(
 	pHSCtrl->L2Filter = 0;
 	pHSCtrl->ICMPv4Deny = 0;
 #ifdef CONFIG_DOT11V_WNM
+	pWNMCtrl->WNMBTMEnable = 0;
 	pWNMCtrl->ProxyARPEnable = 0;
 #ifdef CONFIG_HOTSPOT_R2
 	pWNMCtrl->WNMNotifyEnable = 0;

--- a/package/mtk/drivers/mt_hwifi/src/mt_wifi/feature/hs_r2/wnm.c
+++ b/package/mtk/drivers/mt_hwifi/src/mt_wifi/feature/hs_r2/wnm.c
@@ -3312,15 +3312,11 @@ void PeerWNMAction(IN PRTMP_ADAPTER pAd,
 VOID WNMCtrlInit(IN PRTMP_ADAPTER pAd)
 {
 	PWNM_CTRL pWNMCtrl;
-	BOOLEAN WNMBTMEnable = TRUE;
 	UCHAR Index;
 #ifdef CONFIG_AP_SUPPORT
 	for (Index = 0; Index < MAX_MBSSID_NUM(pAd); Index++) {
 		pWNMCtrl = &pAd->ApCfg.MBSSID[Index].WNMCtrl;
-#ifndef CONFIG_HOTSPOT_R2
-		if(pWNMCtrl->WNMBTMEnable)
-			WNMBTMEnable = pWNMCtrl->WNMBTMEnable;
-#endif
+		BOOLEAN WNMBTMEnable = pWNMCtrl->WNMBTMEnable;
 		NdisZeroMemory(pWNMCtrl, sizeof(*pWNMCtrl));
 		RTMP_SEM_EVENT_INIT(&pWNMCtrl->BTMPeerListLock, &pAd->RscSemMemList);
 		NdisAllocateSpinLock(pAd, &pWNMCtrl->ProxyARPListLock);
@@ -3340,6 +3336,7 @@ VOID WNMCtrlInit(IN PRTMP_ADAPTER pAd)
 #ifdef CONFIG_STA_SUPPORT
 	for (Index = 0; Index < MAX_MULTI_STA; Index++) {
 		pWNMCtrl = &pAd->StaCfg[Index].WNMCtrl;
+		BOOLEAN WNMBTMEnable = pWNMCtrl->WNMBTMEnable;
 		NdisZeroMemory(pWNMCtrl, sizeof(*pWNMCtrl));
 		RTMP_SEM_EVENT_INIT(&pWNMCtrl->BTMPeerListLock, &pAd->RscSemMemList);
 		DlListInit(&pWNMCtrl->BTMPeerList);

--- a/package/mtk/drivers/mt_hwifi/src/mt_wifi/profiles/ap_profile.c
+++ b/package/mtk/drivers/mt_hwifi/src/mt_wifi/profiles/ap_profile.c
@@ -2459,6 +2459,8 @@ void WNM_ReadParametersFromFile(
 {
 	INT loop;
 	RTMP_STRING *macptr;
+	/* WNMEnable */
+#ifdef CONFIG_AP_SUPPORT
 	if (RTMPGetKeyParameter("WNMEnable", tmpbuf, 255, buffer, TRUE)) {
 		for (loop = 0, macptr = rstrtok(tmpbuf, ";");
 				(macptr && loop < MAX_MBSSID_NUM(pAd));
@@ -2467,7 +2469,7 @@ void WNM_ReadParametersFromFile(
 			Enable = simple_strtol(macptr, 0, 10);
 			pAd->ApCfg.MBSSID[loop].WNMCtrl.WNMBTMEnable =
 				(Enable > 0) ? TRUE : FALSE;
-			MTWF_DBG(NULL, DBG_CAT_PROTO, CATPROTO_RRM, DBG_LVL_INFO,
+			MTWF_DBG(NULL, DBG_CAT_PROTO, CATPROTO_WNM, DBG_LVL_INFO,
 				"%s::(bDot11vWNMEnable[%d]=%d)\n",
 				__FUNCTION__, loop,
 				pAd->ApCfg.MBSSID[loop].WNMCtrl.WNMBTMEnable);
@@ -2476,6 +2478,29 @@ void WNM_ReadParametersFromFile(
 		for (loop = 0; loop < MAX_MBSSID_NUM(pAd); loop++)
 			pAd->ApCfg.MBSSID[loop].WNMCtrl.WNMBTMEnable = FALSE;
 	}
+#endif /* CONFIG_AP_SUPPORT */
+#ifdef CONFIG_STA_SUPPORT
+		MTWF_DBG(pAd, DBG_CAT_PROTO, CATPROTO_WNM, DBG_LVL_INFO,
+			"pAd->MSTANum=%d\n", pAd->MSTANum);
+	if (RTMPGetKeyParameter("WNMEnable", tmpbuf, 255, buffer, TRUE)) {
+		for (loop = 0, macptr = rstrtok(tmpbuf, ";");
+				(macptr && loop < pAd->MSTANum);
+					macptr = rstrtok(NULL, ";"), loop++) {
+			LONG Enable;
+
+			Enable = simple_strtol(macptr, 0, 10);
+			pAd->StaCfg[loop].WNMCtrl.WNMBTMEnable =
+				(Enable > 0) ? TRUE : FALSE;
+			MTWF_DBG(pAd, DBG_CAT_PROTO, CATPROTO_WNM, DBG_LVL_INFO,
+				"%s::(STA-bDot11vWNMEnable[%d]=%d)\n",
+				__FUNCTION__, loop,
+				pAd->StaCfg[loop].WNMCtrl.WNMBTMEnable);
+		}
+	} else {
+		for (loop = 0; loop < pAd->MSTANum; loop++)
+			pAd->StaCfg[loop].WNMCtrl.WNMBTMEnable = FALSE;
+	}
+#endif /* CONFIG_STA_SUPPORT */
 	return;
 }
 #endif /* CONFIG_DOT11V_WNM */

--- a/package/mtk/drivers/mt_wifi7/src/mt_wifi/feature/hs_r2/hotspot.c
+++ b/package/mtk/drivers/mt_wifi7/src/mt_wifi/feature/hs_r2/hotspot.c
@@ -811,6 +811,7 @@ static VOID HSCtrlOff(
 	pHSCtrl->L2Filter = 0;
 	pHSCtrl->ICMPv4Deny = 0;
 #ifdef CONFIG_DOT11V_WNM
+	pWNMCtrl->WNMBTMEnable = 0;
 	pWNMCtrl->ProxyARPEnable = 0;
 #ifdef CONFIG_HOTSPOT_R2
 	pWNMCtrl->WNMNotifyEnable = 0;

--- a/package/mtk/drivers/mt_wifi7/src/mt_wifi/feature/hs_r2/wnm.c
+++ b/package/mtk/drivers/mt_wifi7/src/mt_wifi/feature/hs_r2/wnm.c
@@ -3312,15 +3312,11 @@ void PeerWNMAction(IN PRTMP_ADAPTER pAd,
 VOID WNMCtrlInit(IN PRTMP_ADAPTER pAd)
 {
 	PWNM_CTRL pWNMCtrl;
-	BOOLEAN WNMBTMEnable = TRUE;
 	UCHAR Index;
 #ifdef CONFIG_AP_SUPPORT
 	for (Index = 0; Index < MAX_MBSSID_NUM(pAd); Index++) {
 		pWNMCtrl = &pAd->ApCfg.MBSSID[Index].WNMCtrl;
-#ifndef CONFIG_HOTSPOT_R2
-		if(pWNMCtrl->WNMBTMEnable)
-			WNMBTMEnable = pWNMCtrl->WNMBTMEnable;
-#endif
+		BOOLEAN WNMBTMEnable = pWNMCtrl->WNMBTMEnable;
 		NdisZeroMemory(pWNMCtrl, sizeof(*pWNMCtrl));
 		RTMP_SEM_EVENT_INIT(&pWNMCtrl->BTMPeerListLock, &pAd->RscSemMemList);
 		NdisAllocateSpinLock(pAd, &pWNMCtrl->ProxyARPListLock);
@@ -3340,6 +3336,7 @@ VOID WNMCtrlInit(IN PRTMP_ADAPTER pAd)
 #ifdef CONFIG_STA_SUPPORT
 	for (Index = 0; Index < MAX_MULTI_STA; Index++) {
 		pWNMCtrl = &pAd->StaCfg[Index].WNMCtrl;
+		BOOLEAN WNMBTMEnable = pWNMCtrl->WNMBTMEnable;
 		NdisZeroMemory(pWNMCtrl, sizeof(*pWNMCtrl));
 		RTMP_SEM_EVENT_INIT(&pWNMCtrl->BTMPeerListLock, &pAd->RscSemMemList);
 		DlListInit(&pWNMCtrl->BTMPeerList);

--- a/package/mtk/drivers/mt_wifi7/src/mt_wifi/profiles/ap_profile.c
+++ b/package/mtk/drivers/mt_wifi7/src/mt_wifi/profiles/ap_profile.c
@@ -2459,6 +2459,8 @@ void WNM_ReadParametersFromFile(
 {
 	INT loop;
 	RTMP_STRING *macptr;
+	/* WNMEnable */
+#ifdef CONFIG_AP_SUPPORT
 	if (RTMPGetKeyParameter("WNMEnable", tmpbuf, 255, buffer, TRUE)) {
 		for (loop = 0, macptr = rstrtok(tmpbuf, ";");
 				(macptr && loop < MAX_MBSSID_NUM(pAd));
@@ -2467,7 +2469,7 @@ void WNM_ReadParametersFromFile(
 			Enable = simple_strtol(macptr, 0, 10);
 			pAd->ApCfg.MBSSID[loop].WNMCtrl.WNMBTMEnable =
 				(Enable > 0) ? TRUE : FALSE;
-			MTWF_DBG(NULL, DBG_CAT_PROTO, CATPROTO_RRM, DBG_LVL_INFO,
+			MTWF_DBG(NULL, DBG_CAT_PROTO, CATPROTO_WNM, DBG_LVL_INFO,
 				"%s::(bDot11vWNMEnable[%d]=%d)\n",
 				__FUNCTION__, loop,
 				pAd->ApCfg.MBSSID[loop].WNMCtrl.WNMBTMEnable);
@@ -2476,6 +2478,29 @@ void WNM_ReadParametersFromFile(
 		for (loop = 0; loop < MAX_MBSSID_NUM(pAd); loop++)
 			pAd->ApCfg.MBSSID[loop].WNMCtrl.WNMBTMEnable = FALSE;
 	}
+#endif /* CONFIG_AP_SUPPORT */
+#ifdef CONFIG_STA_SUPPORT
+		MTWF_DBG(pAd, DBG_CAT_PROTO, CATPROTO_WNM, DBG_LVL_INFO,
+			"pAd->MSTANum=%d\n", pAd->MSTANum);
+	if (RTMPGetKeyParameter("WNMEnable", tmpbuf, 255, buffer, TRUE)) {
+		for (loop = 0, macptr = rstrtok(tmpbuf, ";");
+				(macptr && loop < pAd->MSTANum);
+					macptr = rstrtok(NULL, ";"), loop++) {
+			LONG Enable;
+
+			Enable = simple_strtol(macptr, 0, 10);
+			pAd->StaCfg[loop].WNMCtrl.WNMBTMEnable =
+				(Enable > 0) ? TRUE : FALSE;
+			MTWF_DBG(pAd, DBG_CAT_PROTO, CATPROTO_WNM, DBG_LVL_INFO,
+				"%s::(STA-bDot11vWNMEnable[%d]=%d)\n",
+				__FUNCTION__, loop,
+				pAd->StaCfg[loop].WNMCtrl.WNMBTMEnable);
+		}
+	} else {
+		for (loop = 0; loop < pAd->MSTANum; loop++)
+			pAd->StaCfg[loop].WNMCtrl.WNMBTMEnable = FALSE;
+	}
+#endif /* CONFIG_STA_SUPPORT */
 	return;
 }
 #endif /* CONFIG_DOT11V_WNM */


### PR DESCRIPTION
1. Originally, WMN was enabled globally by default, and settings in the .dat configuration file were ineffective.
2. The driver was modified to make the configuration settings effective and to support multiple MBSSIDs, each independent of the others.