### PR TITLE
luci-app-mtwifi-cfg: Block channel_analysis(AX)

### DIFF
--- a/package/mtk/applications/luci-app-mtwifi-cfg/root/etc/uci-defaults/luci-app-mtwifi-cfg.default
+++ b/package/mtk/applications/luci-app-mtwifi-cfg/root/etc/uci-defaults/luci-app-mtwifi-cfg.default
@@ -4,9 +4,9 @@ if [ -d /www/luci-static/resources/view/network ]; then
 	mv -f /usr/share/luci-app-mtwifi-cfg/wireless-mtk.js /www/luci-static/resources/view/network/wireless.js
 fi
 
-# if [ -d /usr/share/luci/menu.d ]; then
-# 	mv -f /usr/share/luci-app-mtwifi-cfg/luci-mod-status.json /usr/share/luci/menu.d/luci-mod-status.json
-# fi
+if [ -d /usr/share/luci/menu.d ]; then
+	mv -f /usr/share/luci-app-mtwifi-cfg/luci-mod-status.json /usr/share/luci/menu.d/luci-mod-status.json
+fi
 
 luci_network_js="/www/luci-static/resources/network.js"
 

--- a/package/mtk/applications/luci-app-mtwifi-cfg/root/usr/share/luci-app-mtwifi-cfg/luci-mod-status.json
+++ b/package/mtk/applications/luci-app-mtwifi-cfg/root/usr/share/luci-app-mtwifi-cfg/luci-mod-status.json
@@ -11,27 +11,51 @@
 		}
 	},
 
-	"admin/status/iptables": {
-		"title": "Firewall",
-		"order": 2,
-		"action": {
-			"type": "view",
-			"path": "status/iptables"
-		},
-		"depends": {
-			"acl": [ "luci-mod-status-firewall" ]
-		}
-	},
-
 	"admin/status/routes": {
 		"title": "Routing",
-		"order": 3,
+		"order": 2,
 		"action": {
 			"type": "view",
 			"path": "status/routes"
 		},
 		"depends": {
 			"acl": [ "luci-mod-status-routes" ]
+		}
+	},
+
+	"admin/status/iptables": {
+		"title": "Firewall",
+		"order": 3,
+		"action": {
+			"type": "view",
+			"path": "status/iptables"
+		},
+		"depends": {
+			"acl": [ "luci-mod-status-firewall" ],
+			"fs": [
+				{ "/usr/sbin/nft": "absent", "/usr/sbin/iptables": "executable" },
+				{ "/usr/sbin/nft": "absent", "/usr/sbin/ip6tables": "executable" }
+			]
+		}
+	},
+
+	"admin/status/nftables": {
+		"title": "Firewall",
+		"order": 3,
+		"action": {
+			"type": "view",
+			"path": "status/nftables"
+		},
+		"depends": {
+			"acl": [ "luci-mod-status-firewall" ],
+			"fs": { "/usr/sbin/nft": "executable" }
+		}
+	},
+
+	"admin/status/nftables/iptables": {
+		"action": {
+			"type": "view",
+			"path": "status/iptables"
 		}
 	},
 
@@ -112,7 +136,7 @@
 	},
 
 	"admin/status/realtime/bandwidth": {
-		"title": "Traffic",
+		"title": "Bandwidth",
 		"order": 2,
 		"action": {
 			"type": "view",


### PR DESCRIPTION
To adapt this feature, too many changes are needed. Even if the feature is adapted, the mt_wifi driver will still disconnect when scanning with a Wi-Fi connection after encryption is enabled. Therefore, it is best to disable it!