### PR TITLE
mediatek: filogic: fix syntax error in rax3000m-emmc-mtk dts

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m-emmc-mtk.dts
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m-emmc-mtk.dts
@@ -224,3 +224,4 @@
 
 &xhci {
 	status = "okay";
+};


### PR DESCRIPTION
The mt7981b-cmcc-rax3000m-emmc-mtk.dts file was truncated, missing the closing bracket for the xhci node. This fixed the compilation error.