### PR TITLE
fix dts errors

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m-emmc-mtk.dts
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m-emmc-mtk.dts
@@ -109,10 +109,10 @@
 						};
 
 						macaddr_factory_2a: macaddr@2a {
-                                                        compatible = "mac-base";
-                                                        reg = <0x2a 0x6>;
-                                                        #nvmem-cell-cells = <1>;
-                                                };
+							compatible = "mac-base";
+							reg = <0x2a 0x6>;
+							#nvmem-cell-cells = <1>;
+						};
 					};
 				};
 			};
@@ -129,7 +129,7 @@
 		phy-mode = "2500base-x";
 		
 		nvmem-cells = <&macaddr_factory_24 0>;
-                nvmem-cell-names = "mac-address";
+		nvmem-cell-names = "mac-address";
 		fixed-link {
 			speed = <2500>;
 			full-duplex;
@@ -144,7 +144,7 @@
 		phy-handle = <&int_gbe_phy>;
 
 		nvmem-cells = <&macaddr_factory_2a 0>;
-                nvmem-cell-names = "mac-address";
+		nvmem-cell-names = "mac-address";
 	};
 };
 
@@ -224,3 +224,4 @@
 
 &xhci {
 	status = "okay";
+};


### PR DESCRIPTION
rm -f /workdir/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/image-mt7981b-philips-hy3000.dtb.tmp
aarch64-openwrt-linux-musl-cpp -nostdinc -x assembler-with-cpp  -I/workdir/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/linux-6.6.95/arch/arm64/boot/dts/mediatek -I/workdir/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/linux-6.6.95/arch/arm64/boot/dts/mediatek/include -I/workdir/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/linux-6.6.95/include/ -I/workdir/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/linux-6.6.95/scripts/dtc/include-prefixes -undef -D__DTS__  -o /workdir/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/image-mt7981b-cmcc-rax3000m-emmc-mtk.dtb.tmp ../dts/mt7981b-cmcc-rax3000m-emmc-mtk.dts
/workdir/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/linux-6.6.95/scripts/dtc/dtc -O dtb -i../dts/ -Wno-interrupt_provider -Wno-unique_unit_address -Wno-unit_address_vs_reg -Wno-avoid_unnecessary_addr_size -Wno-alias_paths -Wno-graph_child_address -Wno-simple_bus_reg   -@ -o /workdir/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/image-mt7981b-cmcc-rax3000m-emmc-mtk.dtb /workdir/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/image-mt7981b-cmcc-rax3000m-emmc-mtk.dtb.tmp
Error: ../dts/mt7981b-cmcc-rax3000m-emmc-mtk.dts:226.18-227.1 syntax error
FATAL ERROR: Unable to parse input tree
make[5]: *** [Makefile:43: /workdir/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/image-mt7981b-cmcc-rax3000m-emmc-mtk.dtb] Error 1
make[5]: Leaving directory '/workdir/openwrt/target/linux/mediatek/image'
make[4]: *** [Makefile:21: install] Error 2
make[4]: Leaving directory '/workdir/openwrt/target/linux/mediatek'
make[3]: *** [Makefile:12: install] Error 2
make[3]: Leaving directory '/workdir/openwrt/target/linux'
time: target/linux/install#136.27#10.85#102.20
    ERROR: target/linux failed to build.
make[2]: *** [target/Makefile:32: target/linux/install] Error 1
make[2]: Leaving directory '/workdir/openwrt'
make[1]: *** [target/Makefile:26: /workdir/openwrt/staging_dir/target-aarch64_cortex-a53_musl/stamp/.target_install] Error 2
make[1]: Leaving directory '/workdir/openwrt'
make: *** [/workdir/openwrt/include/toplevel.mk:233: world] Error 2