### PR TITLE
scripts/patch-kernel.sh: do not try to check files after patch

### DIFF
--- a/scripts/patch-kernel.sh
+++ b/scripts/patch-kernel.sh
@@ -43,12 +43,3 @@ for i in ${patchdir}/${patchpattern} ; do
 	exit 1
     fi
 done
-
-# Check for rejects...
-if [ "`find $targetdir/ '(' -name '*.rej' -o -name '.*.rej' ')' -print`" ] ; then
-    echo "Aborting.  Reject files found."
-    exit 1
-fi
-
-# Remove backup files
-find $targetdir/ '(' -name '*.orig' -o -name '.*.orig' ')' -exec rm -f {} \;


### PR DESCRIPTION
Since we are not using patch -b, *.orig files are only created when there are conflicts, or never according to posix patch.

As such, it doesn't really make sense to always delete *.orig files presuming they are patch backups, even if they are patch backups. Doing so is both deleting potentially useful information for failed patch applications and creating hard to diagnose bugs [1].

In a similar vein, checking for *.rej files does not add any value since we're already checking the patch command's return code.

[1]: openwrt/packages#27485


Link: openwrt/openwrt#20141