### PR TITLE
Improve adapt for cmcc a10

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cmcc-a10-stock.dts
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-a10-stock.dts
@@ -13,24 +13,6 @@
 		label = "ubi";
 		reg = <0x580000 0x4000000>;
 	};
-
-	partition@4580000 {
-		label = "firmware_backup";
-		reg = <0x4580000 0x2000000>;
-		read-only;
-	};
-
-	partition@6580000 {
-		label = "zrsave";
-		reg = <0x6580000 0x100000>;
-		read-only;
-	};
-
-	partition@6680000 {
-		label = "config2";
-		reg = <0x6680000 0x100000>;
-		read-only;
-	};
 };
 
 &spi_nand {

--- a/target/linux/mediatek/dts/mt7981b-cmcc-a10.dts
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-a10.dts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include "mt7981b-cmcc-a10.dtsi"
+
+/ {
+	model = "CMCC A10";
+	compatible = "cmcc,a10", "mediatek,mt7981";
+};
+
+&partitions {
+	partition@580000 {
+		label = "ubi";
+		reg = <0x580000 0x7000000>;
+	};
+};
+
+&spi_nand {
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+};

--- a/target/linux/mediatek/dts/mt7981b-superelectron-zn-m5-stock.dts
+++ b/target/linux/mediatek/dts/mt7981b-superelectron-zn-m5-stock.dts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include "mt7981b-cmcc-a10.dtsi"
+
+/ {
+	model = "SuperElectron ZN-M5 (stock layout)";
+	compatible = "superelectron,zn-m5-stock", "mediatek,mt7981";
+};
+
+&partitions {
+	partition@580000 {
+		label = "ubi";
+		reg = <0x580000 0x4000000>;
+	};
+
+	partition@4580000 {
+		label = "firmware_backup";
+		reg = <0x4580000 0x2000000>;
+		read-only;
+	};
+
+	partition@6580000 {
+		label = "zrsave";
+		reg = <0x6580000 0x100000>;
+		read-only;
+	};
+
+	partition@6680000 {
+		label = "config2";
+		reg = <0x6680000 0x100000>;
+		read-only;
+	};
+};
+
+&spi_nand {
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+};

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1947,6 +1947,32 @@ define Device/bt_r320
 endef
 TARGET_DEVICES += bt_r320
 
+define Device/superelectron_zn-m5-stock
+  DEVICE_VENDOR := SuperElectron
+  DEVICE_MODEL := ZN-M5
+  DEVICE_VARIANT := (stock layout)
+  DEVICE_ALT0_VENDOR := SuperElectron
+  DEVICE_ALT0_MODEL := ZN-M8
+  DEVICE_ALT0_VARIANT := (stock layout)
+  DEVICE_DTS := mt7981b-superelectron-zn-m5-stock
+  DEVICE_DTS_DIR := ../dts
+  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 65536k
+  KERNEL_IN_UBI := 1
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  KERNEL = kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS = kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
+endef
+TARGET_DEVICES += superelectron_zn-m5-stock
+
 define Device/tplink_re6000xd
   DEVICE_VENDOR := TP-Link
   DEVICE_MODEL := RE6000XD

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -536,6 +536,28 @@ define Device/cetron_ct3003-ubootmod
 endef
 TARGET_DEVICES += cetron_ct3003-ubootmod
 
+define Device/cmcc_a10
+  DEVICE_VENDOR := CMCC
+  DEVICE_MODEL := A10
+  DEVICE_DTS := mt7981b-cmcc-a10
+  DEVICE_DTS_DIR := ../dts
+  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 114688k
+  KERNEL_IN_UBI := 1
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  KERNEL = kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS = kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
+endef
+TARGET_DEVICES += cmcc_a10
+
 define Device/cmcc_a10-stock
   DEVICE_VENDOR := CMCC
   DEVICE_MODEL := A10

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -540,12 +540,6 @@ define Device/cmcc_a10-stock
   DEVICE_VENDOR := CMCC
   DEVICE_MODEL := A10
   DEVICE_VARIANT := (stock layout)
-  DEVICE_ALT0_VENDOR := SuperElectron
-  DEVICE_ALT0_MODEL := ZN-M5
-  DEVICE_ALT0_VARIANT := (stock layout)
-  DEVICE_ALT1_VENDOR := SuperElectron
-  DEVICE_ALT1_MODEL := ZN-M8
-  DEVICE_ALT1_VARIANT := (stock layout)
   DEVICE_DTS := mt7981b-cmcc-a10-stock
   DEVICE_DTS_DIR := ../dts
   SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb


### PR DESCRIPTION
- cmcc-a10 and zn-m5 shared a stock layout device tree and used an incorrect partition, causing cmcc-a10 fail to boot, now they were separated.
- add cmcc-a10 112m ubi layout