### PR TITLE
Remove lan1 port definition from device tree

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-new-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-new-common.dtsi
@@ -252,11 +252,6 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		port@0 {
-			reg = <0>;
-			label = "lan1";
-		};
-
 		port@1 {
 			reg = <1>;
 			label = "lan2";


### PR DESCRIPTION
Removed the definition for port@0 (lan1) from the device tree.