### PR TITLE
mtd_spinand: fix FORESEE NAND false bad blocks

### DIFF
--- a/package/boot/uboot-mediatek/patches/101-01-mtd-spinand-add-support-for-FORESEE-F35SQA002G.patch
+++ b/package/boot/uboot-mediatek/patches/101-01-mtd-spinand-add-support-for-FORESEE-F35SQA002G.patch
@@ -66,8 +66,8 @@ Link: https://lore.kernel.org/linux-mtd/20231002140458.147605-1-mmkurbanov@salut
 +		SPINAND_PROG_LOAD(true, 0, NULL, 0));
 +
 +static SPINAND_OP_VARIANTS(update_cache_variants,
-+		SPINAND_PROG_LOAD_X4(false, 0, NULL, 0),
-+		SPINAND_PROG_LOAD(false, 0, NULL, 0));
++		SPINAND_PROG_LOAD_X4(true, 0, NULL, 0),
++		SPINAND_PROG_LOAD(true, 0, NULL, 0));
 +
 +static int f35sqa002g_ooblayout_ecc(struct mtd_info *mtd, int section,
 +				    struct mtd_oob_region *region)

--- a/target/linux/generic/backport-6.6/411-v6.7-mtd-spinand-add-support-for-FORESEE-F35SQA002G.patch
+++ b/target/linux/generic/backport-6.6/411-v6.7-mtd-spinand-add-support-for-FORESEE-F35SQA002G.patch
@@ -63,8 +63,8 @@ Link: https://lore.kernel.org/linux-mtd/20231002140458.147605-1-mmkurbanov@salut
 +		SPINAND_PROG_LOAD(true, 0, NULL, 0));
 +
 +static SPINAND_OP_VARIANTS(update_cache_variants,
-+		SPINAND_PROG_LOAD_X4(false, 0, NULL, 0),
-+		SPINAND_PROG_LOAD(false, 0, NULL, 0));
++		SPINAND_PROG_LOAD_X4(true, 0, NULL, 0),
++		SPINAND_PROG_LOAD(true, 0, NULL, 0));
 +
 +static int f35sqa002g_ooblayout_ecc(struct mtd_info *mtd, int section,
 +				    struct mtd_oob_region *region)


### PR DESCRIPTION
Force update_cache_variants to use reset for Foresee NAND with bad blocks. This fixes devices with FORESEE nand bricked after few reboots.