### PR TITLE
package: mt798x-2p5g-phy-firmware-internal: fix phy firmware load failed

### DIFF
--- a/package/mtk/applications/mt798x-2p5g-phy-firmware-internal/Makefile
+++ b/package/mtk/applications/mt798x-2p5g-phy-firmware-internal/Makefile
@@ -12,7 +12,7 @@ define KernelPackage/mt798x-2p5g-phy
   SUBMENU:=Network Devices
   TITLE:=MediaTek MT798x 2.5G PHY driver
   DEPENDS:=@TARGET_mediatek +mt798x-2p5g-phy-firmware-internal
-  KCONFIG:=CONFIG_MEDIATEK_2P5GE_PHY=y
+  KCONFIG:=CONFIG_MEDIATEK_2P5GE_PHY=m
   FILES:=$(LINUX_DIR)/drivers/net/phy/mediatek/mtk-2p5ge.ko
   AUTOLOAD:=$(call AutoLoad,73,mtk-2p5ge)
 endef


### PR DESCRIPTION
make mtk-2p5ge as a kernel module loadded after filesystem get ready 
Fix the issus where the filesystem is not ready when the phy driver try to load phy firmware

Fixes: ad61855ac2 ("mt7988:add tl-7dr7299 v1 device")