### PR TITLE
uboot-mediatek: mtd: spinand: fix ecc bitflips methods for heyangtek

### DIFF
--- a/package/boot/uboot-mediatek/patches/344-mtd-spinand-add-support-for-HeYangTek-HYF1GQ4UDACAE.patch
+++ b/package/boot/uboot-mediatek/patches/344-mtd-spinand-add-support-for-HeYangTek-HYF1GQ4UDACAE.patch
@@ -110,10 +110,10 @@ Subject: [PATCH] mtd: spinand: add support for HeYangTek HYF1GQ4UDACAE
 +		return -EBADMSG;
 +
 +	case STATUS_ECC_HAS_BITFLIPS:
-+		return nanddev_get_ecc_conf(nand)->strength >> 1;
++		return nand->eccreq.strength >> 1;
 +
 +	case STATUS_ECC_LIMIT_BITFLIPS:
-+		return nanddev_get_ecc_conf(nand)->strength;
++		return nand->eccreq.strength;
 +
 +	default:
 +		break;


### PR DESCRIPTION
Since https://github.com/padavanonly/immortalwrt-mt798x-6.6/pull/387 make an error in compile.

```bash
drivers/mtd/nand/spi/heyangtek.c:77:50:
error: invalid type argument of '->' (have 'int')

drivers/mtd/nand/spi/heyangtek.c:80:50:
error: invalid type argument of '->' (have 'int')

warning: implicit declaration of function 'nanddev_get_ecc_conf'
```

This writing style is from the new version and is not applicable to the current respositroy.