### PR TITLE
mediatek: filogic: mt7988a.dtsi: adjust ethernet reg size to avoid cr…

### DIFF
--- a/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a.dtsi
+++ b/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a.dtsi
@@ -1479,7 +1479,7 @@
 		eth: ethernet@15100000 {
 			compatible = "mediatek,mt7988-eth";
 			reg = <0 0x15100000 0 0x80000>,
-			      <0 0x15400000 0 0x380000>;
+			      <0 0x15400000 0 0x200000>;
 			interrupts = <GIC_SPI 189 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 190 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 191 IRQ_TYPE_LEVEL_HIGH>,


### PR DESCRIPTION
Reduce second memory region size from 0x380000 to 0x200000 to prevent overlap with crypto engine at 0x15600000, fixing crypto-safexcel probe failure due to resource busy (-16) (-EBUSY).