### PR TITLE
S20 improvements

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-supergateway-s20l.dts
+++ b/target/linux/mediatek/dts/mt7986a-supergateway-s20l.dts
@@ -44,22 +44,30 @@
 
 				port@0 {
 					reg = <0>;
+					label = "wan";
+
+					nvmem-cells = <&macaddr_factory_24 0>;
+					nvmem-cell-names = "mac-address";
 				};
 
 				port@1 {
 					reg = <1>;
+					label = "lan4";
 				};
 
 				port@2 {
 					reg = <2>;
+					label = "lan3";
 				};
 
 				port@3 {
 					reg = <3>;
+					label = "lan2";
 				};
 
 				port@4 {
 					reg = <4>;
+					label = "lan1";
 				};
 
 				port@6 {

--- a/target/linux/mediatek/dts/mt7986a-supergateway-s20m.dts
+++ b/target/linux/mediatek/dts/mt7986a-supergateway-s20m.dts
@@ -49,22 +49,30 @@
 
 				port@0 {
 					reg = <0>;
+					label = "wan";
+
+					nvmem-cells = <&macaddr_factory_24 0>;
+					nvmem-cell-names = "mac-address";
 				};
 
 				port@1 {
 					reg = <1>;
+					label = "lan4";
 				};
 
 				port@2 {
 					reg = <2>;
+					label = "lan3";
 				};
 
 				port@3 {
 					reg = <3>;
+					label = "lan2";
 				};
 
 				port@4 {
 					reg = <4>;
+					label = "lan1";
 				};
 
 				port@6 {

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -178,8 +178,8 @@ smartrg,sdg-8733a)
 	;;
 supergateway,s20l|\
 supergateway,s20p)
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "blue:wlan-5ghz" "phy1-ap0"
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "blue:wlan-2ghz" "phy0-ap0"
+	ucidef_set_led_netdev "wlan5g" "WLAN5G" "blue:wlan-5ghz" "rax0"
+	ucidef_set_led_netdev "wlan2g" "WLAN2G" "blue:wlan-2ghz" "ra0"
 	ucidef_set_led_timer "sys" "SYS" "blue:status" "1000" "2000"
 	;;
 supergateway,s20m)


### PR DESCRIPTION
- fix missing labels and mac address for mt7986a-supergateway-s20m/s20l
- fix supergateway s20l/s20p LED network device names 