### PR TITLE
Fix BPI-R4 SFP Module Not Working

### DIFF
--- a/target/linux/mediatek/patches-6.6/997-sfp-rtl8672-accept-zero-phys-id-24.10.patch
+++ b/target/linux/mediatek/patches-6.6/997-sfp-rtl8672-accept-zero-phys-id-24.10.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000001 Mon Sep 17 00:00:00 2001
+From: BananaPi-R4 community <openwrt@bananapi.org>
+Date: Sat, 24 May 2025 00:00:00 +0800
+Subject: [PATCH] net: phy: sfp: accept all-zero phys_id for RTL8672/RTL9601C modules
+
+Chinese ISP ONT SFP sticks based on Realtek RTL8672 and RTL9601C chips
+(e.g. locked Huawei, ZTE, Nokia modules issued by China Telecom, China
+Unicom, China Mobile) may return all-zero EEPROM data even when read
+byte-by-byte via the existing quirk path.  The driver then prints:
+
+  sfp sfp1: module is not supported - phys id 0x00 0x00
+
+and rejects the module because phys_id 0x00 is not SFF8024_ID_SFP (0x03).
+
+The all-zero EEPROM still passes the base checksum check (sum of 63
+zero-bytes equals zero, cc_base byte is also zero), so the rejection
+happens only in sfp_module_supported().
+
+Extend sfp_module_supported() to accept modules whose phys_id AND
+phys_ext_id are both 0x00, treating them as a valid SFP.  This mirrors
+the Ubiquiti U-Fiber Instant special-case already present in the
+function and is restricted to the (phys_id, phys_ext_id) == (0, 0)
+combination so that genuinely unknown module identifiers with a non-zero
+phys_ext_id are still rejected.
+
+Signed-off-by: BananaPi-R4 community <openwrt@bananapi.org>
+---
+ drivers/net/phy/sfp.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/drivers/net/phy/sfp.c b/drivers/net/phy/sfp.c
+index 165c624..88f0bad 100644
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -314,6 +314,13 @@ static bool sfp_module_supported(const struct sfp_eeprom_id *id)
+ 	    id->base.phys_ext_id == SFP_PHYS_EXT_ID_SFP)
+ 		return true;
+ 
++	/* RTL8672/RTL9601C based GPON ONT sticks (e.g. locked Chinese ISP
++	 * modules) return all-zero EEPROM even after byte-by-byte I/O.
++	 * Accept (phys_id, phys_ext_id) == (0x00, 0x00) as standard SFP.
++	 */
++	if (!id->base.phys_id && !id->base.phys_ext_id)
++		return true;
++
+ 	/* SFP GPON module Ubiquiti U-Fiber Instant has in its EEPROM stored
+ 	 * phys id SFF instead of SFP. Therefore mark this module explicitly
+ 	 * as supported based on vendor name and pn match.
+-- 
+2.45.2

--- a/target/linux/mediatek/patches-6.6/998-sfp-rtl8672-reduce-false-positive-warning.patch
+++ b/target/linux/mediatek/patches-6.6/998-sfp-rtl8672-reduce-false-positive-warning.patch
@@ -1,0 +1,93 @@
+From 0000000000000000000000000000000000000001 Mon Sep 17 00:00:00 2001
+From: BananaPi-R4 community <openwrt@bananapi.org>
+Date: Thu, 18 Jun 2026 00:00:00 +0800
+Subject: [PATCH] net: phy: sfp: reduce false-positive RTL8672 warning on
+ MT7988
+
+The sfp_id_needs_byte_io() heuristic detects that multi-byte I2C reads
+return only the first byte of each block followed by zeros and assumes
+the module is an RTL8672/RTL9601C GPON ONT stick.  On MediaTek MT7988
+(BPI-R4) the I2C controller may exhibit the same multi-byte read
+limitation with any SFP module, including standard Aquantia AQR113C
+10G-T copper modules and CISCO-AVAGO SFBR-709SMZ-CS fibre modules,
+producing a misleading "Detected broken RTL8672/RTL9601C emulated
+EEPROM" warning in dmesg.
+
+After switching to byte-at-a-time I/O and re-reading the EEPROM
+successfully, check the vendor_name field.  If it contains meaningful
+printable ASCII text, the EEPROM data is valid and the multi-byte
+failure was a platform I2C issue, not an actual RTL8672 module.  In that
+case, emit a less alarming info message instead.
+
+The original "Detected broken RTL8672/RTL9601C emulated EEPROM" message
+is still shown when even the byte-at-a-time re-read yields all-zero,
+all-space, or otherwise invalid vendor data, indicating a genuine
+RTL8672/RTL9601C module with a blank EEPROM or a module that is not yet
+ready.
+
+Signed-off-by: BananaPi-R4 community <openwrt@bananapi.org>
+---
+ drivers/net/phy/sfp.c | 36 ++++++++++++++++++++++++++++++------
+ 1 file changed, 30 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/phy/sfp.c b/drivers/net/phy/sfp.c
+index 88f0bad..902a5f3 100644
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -2168,6 +2168,23 @@ static bool sfp_id_needs_byte_io(struct sfp *sfp, void *buf, size_t len)
+ 	return true;
+ }
+ 
++static bool sfp_id_has_valid_vendor_name(const char *name, size_t len)
++{
++	bool seen = false;
++	size_t i;
++
++	for (i = 0; i < len; i++) {
++		if (name[i] == ' ' || name[i] == '\0')
++			continue;
++		if (name[i] < 0x20 || name[i] > 0x7e)
++			return false;
++
++		seen = true;
++	}
++
++	return seen;
++}
++
+ static int sfp_cotsworks_fixup_check(struct sfp *sfp, struct sfp_eeprom_id *id)
+ {
+ 	u8 check;
+@@ -2248,10 +2265,6 @@ static int sfp_sm_mod_probe(struct sfp *sfp, bool report)
+ 	 * is really required and we have no other option.
+ 	 */
+ 	if (sfp_id_needs_byte_io(sfp, &id.base, sizeof(id.base))) {
+-		dev_info(sfp->dev,
+-			 "Detected broken RTL8672/RTL9601C emulated EEPROM\n");
+-		dev_info(sfp->dev,
+-			 "Switching to reading EEPROM to one byte at a time\n");
+ 		sfp->i2c_block_size = 1;
+ 
+ 		ret = sfp_read(sfp, false, 0, &id.base, sizeof(id.base));
+@@ -2268,6 +2281,19 @@ static int sfp_sm_mod_probe(struct sfp *sfp, bool report)
+ 				ERR_PTR(ret));
+ 			return -EAGAIN;
+ 		}
++
++		/* If the byte-at-a-time re-read yields a valid vendor
++		 * name, the module is a standard SFP whose multi-byte read
++		 * failed for platform (I2C) reasons rather than because it
++		 * is an RTL8672/RTL9601C GPON stick.  Tone down the warning.
++		 */
++		if (sfp_id_has_valid_vendor_name(id.base.vendor_name,
++						 sizeof(id.base.vendor_name)))
++			dev_info(sfp->dev,
++				 "I2C multi-byte read unreliable, falling back to byte-at-a-time\n");
++		else
++			dev_info(sfp->dev,
++				 "Detected broken RTL8672/RTL9601C emulated EEPROM\n");
+ 	}
+ 
+ 	/* Cotsworks do not seem to update the checksums when they
+-- 
+2.45.2


### PR DESCRIPTION
Fix BPI-R4 SFP Module Not Working :Detected broken RTL8672/RTL9601C emulated EEPROM