### PR TITLE
mediatek: remove nmbm attribution for TP-Link WMA301 2.1 device tree

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-tplink-wma301_2.1.dts
+++ b/target/linux/mediatek/dts/mt7981b-tplink-wma301_2.1.dts
@@ -111,10 +111,6 @@
 		spi-rx-bus-width = <4>;
 		spi-tx-bus-width = <4>;
 
-		mediatek,nmbm;
-		mediatek,bmt-max-ratio = <1>;
-		mediatek,bmt-max-reserved-blocks = <64>;
-
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;


### PR DESCRIPTION
TP-Link WMA301 2.1 use 128MB flash, in current device tree, the nmbm attribution is set, but all partitions are fully used, so nmbm is not needed.