### PR TITLE
package: mtk: switch: fix mt753x switch script outdated grammar

### DIFF
--- a/package/mtk/applications/switch/files/switch_ctl.init
+++ b/package/mtk/applications/switch/files/switch_ctl.init
@@ -9,7 +9,7 @@ service_triggers() {
 
 start_service() {
     logger -t "switch_ctl" "restart mt753x all ports"
-    source "/usr/sbin/switch_ctl.sh"
+    . "/usr/sbin/switch_ctl.sh"
     sw_poweroff_ports "0 1 2 3 4"
     sleep 2
     sw_poweron_ports "0 1 2 3 4"

--- a/package/mtk/applications/switch/files/switch_ctl.sh
+++ b/package/mtk/applications/switch/files/switch_ctl.sh
@@ -2,6 +2,13 @@
 
 [ ! -x /usr/sbin/switch ] && return
 
+sw_read_phy_reg0() {
+	local reg_value
+	reg_value=$(switch phy cl22 r "$1" 0 2>/dev/null | awk -F'=' 'NF >= 3 {gsub(/[[:space:]]/, "", $3); print $3; exit}')
+	[ -n "$reg_value" ] || reg_value=0
+	printf '%s\n' "$reg_value"
+}
+
 # power off ports
 # $1 ports list, ex: "1 2 3"
 sw_poweroff_ports() {
@@ -10,10 +17,10 @@ sw_poweroff_ports() {
 	[ -z "$1" ] && return 1
 	for p in $1; do
 		# read original value of register 0
-		ori_value=$(switch phy cl22 r $p 0 | awk -F'=' '{print $3}')
+		ori_value=$(sw_read_phy_reg0 "$p")
 
 		# register 0, bit 11 is power down control bit, set to 1
-		set_value=$(($ori_value | 0x800))
+		set_value=$((ori_value | 0x800))
 		switch phy cl22 w $p 0 $set_value >/dev/null 2>&1
 	done
 }
@@ -26,10 +33,10 @@ sw_poweron_ports() {
 	[ -z "$1" ] && return 1
 	for p in $1; do
 		# read original value of register 0
-		ori_value=$(switch phy cl22 r $p 0 | awk -F'=' '{print $3}')
+		ori_value=$(sw_read_phy_reg0 "$p")
 
 		# register 0, bit 11 is power down control bit, set to 0
-		set_value=$(($ori_value & ~0x800))
+		set_value=$((ori_value & ~0x800))
 		switch phy cl22 w $p 0 $set_value >/dev/null 2>&1
 	done
 }
@@ -41,10 +48,10 @@ sw_restart_port() {
 	[ -z "$1" ] && return 1
 	for p in $1; do
 		# read original value of register 0
-		ori_value=$(switch phy cl22 r $p 0 | awk -F'=' '{print $3}')
+		ori_value=$(sw_read_phy_reg0 "$p")
 
 		# register 0, bit 9 is Restart Auto-Negotiation bit, set to 1
-		set_value=$(($ori_value | 0x200))
+		set_value=$((ori_value | 0x200))
 		switch phy cl22 w $p 0 $set_value >/dev/null 2>&1
 	done
 }


### PR DESCRIPTION
This commit helps eliminate noise in the system logs.