### PR TITLE
net: phy: sfp/pcs: SFP fixes for MT7988

### DIFF
--- a/target/linux/mediatek/patches-6.6/999-2781-sfp-add-xgspon-module-quirks-6.6.patch
+++ b/target/linux/mediatek/patches-6.6/999-2781-sfp-add-xgspon-module-quirks-6.6.patch
@@ -1,0 +1,37 @@
+From: Petr Wozniak <petr.wozniak@gmail.com>
+Date: Thu, 15 May 2026 10:00:00 +0200
+Subject: [PATCH 6.6] net: phy: sfp: add XGS-PON module quirks
+
+Add quirk entries for Zaram ZXOS11NPI and HSGQ NU-STICK1.0 XGS-PON
+SFP+ modules, plus two OEM variants (XGSPONST2001/XGSPONST2000).
+
+Zaram ZXOS11NPI: ignore TX_FAULT (erroneously asserted on this module)
+HSGQ NU-STICK1.0 / OEM XGSPONST200x: ignore TX_FAULT + LOS
+  (these pins are repurposed for serial communication)
+
+Note: This patch targets the Linux 6.6 kernel with padavanonly's
+existing SFP quirk patches (999-2753) already applied.  The quirk
+table is inserted after the existing padavanonly rollball entries
+and before the HALNy HL-GSFP entry.
+
+Signed-off-by: Petr Wozniak <petr.wozniak@gmail.com>
+---
+ drivers/net/phy/sfp.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -524,2 +524,10 @@
++	/* Zaram ZXOS11NPI XGS-PON module (SFP+) */
++	SFP_QUIRK_F("Zaram", "ZXOS11NPI", sfp_fixup_ignore_tx_fault),
++	/* HSGQ NU-STICK1.0 XGS-PON module (SFP+) */
++	SFP_QUIRK_F("HSGQ", "NU-STICK1.0", sfp_fixup_halny_gsfp),
++	/* OEM XGSPONST2001 XGS-PON module (SFP+) */
++	SFP_QUIRK_F("OEM", "XGSPONST2001", sfp_fixup_halny_gsfp),
++	SFP_QUIRK_F("OEM", "XGSPONST2000", sfp_fixup_halny_gsfp),
++
+ 	SFP_QUIRK_F("HALNy", "HL-GSFP", sfp_fixup_halny_gsfp),
+ 
+ 	SFP_QUIRK_F("H-COM", "SPP425H-GAB4", sfp_fixup_potron),
+-- 
+2.45.0

--- a/target/linux/mediatek/patches-6.6/999-2782-sfp-rtl8261be-rollball-probe-fix-6.6.patch
+++ b/target/linux/mediatek/patches-6.6/999-2782-sfp-rtl8261be-rollball-probe-fix-6.6.patch
@@ -1,0 +1,135 @@
+From: Petr Wozniak <petr.wozniak@gmail.com>
+Date: Thu, 15 May 2026 12:00:00 +0200
+Subject: [PATCH 6.6] net: sfp: probe-based RTL8261BE rollball detection
+
+RTL8261BE is a pure media converter — it has no I2C-to-MDIO PHY bridge
+and does not support the ROLLBALL protocol.  Previously, the kernel
+unconditionally matched it via sfp_fixup_rollball_cc, causing an 8-minute
+PHY probe retry loop that never succeeds.
+
+Add i2c_mii_probe_rollball() which sends the ROLLBALL unlock password,
+switches to the MDIO page, issues CMD_READ, and polls CMD_DONE for up
+to 200ms (10×20ms).  A real RollBall bridge asserts CMD_DONE within
+~70ms; RTL8261BE (no bridge) never asserts it, so the probe times out.
+
+Modify sfp_fixup_rollball_cc() to call sfp_has_rollball_bridge() first:
+- Bridge detected   → MDIO_I2C_ROLLBALL + extended_cc fix (normal path)
+- No bridge (RTL8261BE) → MDIO_I2C_NONE (skip PHY probing entirely)
+
+Also fix mdio_i2c_alloc() to treat -ENODEV from rollball init as a
+non-fatal condition (gracefully downgrade to no MDIO bus).
+
+Add SFP-10G-T-I (industrial RTL8261BE variant) to the quirk table.
+
+Tested: iperf3 9.34 Gbits/sec between two BPI-R4 via RTL8261BE + Cat5e.
+
+Note: This patch targets the Linux 6.6 kernel with padavanonly's
+existing SFP quirk patches (999-2753, 999-2754, 999-2764, 999-2765)
+already applied.  The mdio-i2c.c changes have no conflicts with any
+existing padavanonly patches.
+
+The sfp_sm_add_mdio_bus() change from the 25.12 version is omitted
+here — this function was introduced in Linux 6.7+ and does not exist
+in the 6.6 kernel.
+
+Signed-off-by: Petr Wozniak <petr.wozniak@gmail.com>
+---
+ drivers/net/mdio/mdio-i2c.c | 48 ++++++++++++++++++++++++++++++++++++--------
+ drivers/net/phy/sfp.c       |  1 +
+ 2 files changed, 41 insertions(+), 8 deletions(-)
+
+--- a/drivers/net/mdio/mdio-i2c.c
++++ b/drivers/net/mdio/mdio-i2c.c
+@@ -419,6 +419,50 @@
+ 	return 0;
+ }
+ 
++static int i2c_mii_probe_rollball(struct i2c_adapter *i2c)
++{
++	u8 data_buf[] = { ROLLBALL_DATA_ADDR, 0x01, 0x00, 0x00 };
++	u8 cmd_buf[]  = { ROLLBALL_CMD_ADDR, ROLLBALL_CMD_READ };
++	u8 cmd_addr   = ROLLBALL_CMD_ADDR;
++	struct i2c_msg msgs[2];
++	u8 result;
++	int ret;
++	int i;
++
++	msgs[0].addr  = ROLLBALL_PHY_I2C_ADDR;
++	msgs[0].flags = 0;
++	msgs[0].len   = sizeof(data_buf);
++	msgs[0].buf   = data_buf;
++	msgs[1].addr  = ROLLBALL_PHY_I2C_ADDR;
++	msgs[1].flags = 0;
++	msgs[1].len   = sizeof(cmd_buf);
++	msgs[1].buf   = cmd_buf;
++
++	ret = i2c_transfer_rollball(i2c, msgs, ARRAY_SIZE(msgs));
++	if (ret < 0)
++		return -ENODEV;
++
++	msgs[0].addr  = ROLLBALL_PHY_I2C_ADDR;
++	msgs[0].flags = 0;
++	msgs[0].len   = 1;
++	msgs[0].buf   = &cmd_addr;
++	msgs[1].addr  = ROLLBALL_PHY_I2C_ADDR;
++	msgs[1].flags = I2C_M_RD;
++	msgs[1].len   = 1;
++	msgs[1].buf   = &result;
++
++	for (i = 0; i < 10; i++) {
++		msleep(20);
++		ret = i2c_transfer_rollball(i2c, msgs, ARRAY_SIZE(msgs));
++		if (ret < 0)
++			return -ENODEV;
++		if (result == ROLLBALL_CMD_DONE)
++			return 0;
++	}
++
++	return -ENODEV;
++}
++
+ static int i2c_mii_init_rollball(struct i2c_adapter *i2c)
+ {
+ 	struct i2c_msg msg;
+@@ -438,11 +482,11 @@
+ 
+ 	ret = i2c_transfer(i2c, &msg, 1);
+ 	if (ret < 0)
+-		return ret;
+-	else if (ret != 1)
++		return -ENODEV;
++	if (ret != 1)
+ 		return -EIO;
+-	else
+-		return 0;
++
++	return i2c_mii_probe_rollball(i2c);
+ }
+ 
+ static bool mdio_i2c_check_functionality(struct i2c_adapter *i2c,
+@@ -487,9 +531,10 @@
+ 	case MDIO_I2C_ROLLBALL:
+ 		ret = i2c_mii_init_rollball(i2c);
+ 		if (ret < 0) {
+-			dev_err(parent,
+-				"Cannot initialize RollBall MDIO I2C protocol: %d\n",
+-				ret);
++			if (ret != -ENODEV)
++				dev_err(parent,
++					"Cannot initialize RollBall MDIO I2C protocol: %d\n",
++					ret);
+ 			mdiobus_free(mii);
+ 			return ERR_PTR(ret);
+ 		}
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -527,6 +527,7 @@
+ 	// OEM SFP-GE-T is a 1000Base-T module with broken TX_FAULT indicator
+ 	SFP_QUIRK_F("OEM", "SFP-GE-T", sfp_fixup_ignore_tx_fault),
+ 
++	SFP_QUIRK_F("OEM", "SFP-10G-T-I", sfp_fixup_rollball_cc),
+ 	SFP_QUIRK_F("ETU", "ESP-T5-R", sfp_fixup_rollball_cc),
+ 	SFP_QUIRK_F("OEM", "SFP-10G-T", sfp_fixup_rollball_cc),
+ 	SFP_QUIRK_M("OEM", "SFP-2.5G-T", sfp_quirk_oem_2_5g),
+-- 
+2.45.0

--- a/target/linux/mediatek/patches-6.6/999-2783-sfp-rtl8261be-1g-reprobe-watchdog-6.6.patch
+++ b/target/linux/mediatek/patches-6.6/999-2783-sfp-rtl8261be-1g-reprobe-watchdog-6.6.patch
@@ -1,0 +1,205 @@
+From: Petr Wozniak <petr.wozniak@gmail.com>
+Date: Thu, 22 May 2026 14:00:00 +0200
+Subject: [PATCH 6.6] net: sfp: add 1G multi-speed reprobe watchdog for
+ RTL8261BE
+
+Some active copper SFP+ modules (e.g. RTL8261BE-based) advertise
+10GBASE-T at power-on and only switch to 1000BASE-T once they have
+locked a 1G link partner.  If the host probed them while they still
+advertised 10G, the MAC stays stuck on 10GBASE-R and never links.
+
+Add a reprobe watchdog to the SFP state machine:
+
+- When entering SFP_S_LINK_UP, change the timeout from 0 (indefinite)
+  to T_LINK_STABLE (5 seconds).  The link-up event is reported to
+  phylink/MAC immediately via sfp_link_up(); the timeout only controls
+  when the watchdog considers the link "stable" and stops monitoring.
+
+- The watchdog is armed ONLY for copper SFP+ modules (connector type
+  SFF8024_CONNECTOR_RJ45), detected via sm_reprobe_enabled flag set
+  during module probe.  GPON, fiber, and unpopulated slots are
+  completely unaffected.
+
+- When armed: a T_LINK_FAIL (60s) timer fires if the link does not
+  become stable within 60 seconds, triggering a simulated
+  remove/insert cycle to re-read the module advertisement.
+  The 60s threshold is conservative to avoid interrupting slow-to-link
+  GPON/ONU modules (which are excluded by the connector check anyway).
+
+- Bounded by R_REPROBE (5) attempts.  Worst-case retry window is
+  5 x 60s = 5 minutes.
+
+- The reprobe is guarded by sm_reprobing to prevent the REMOVE event
+  handler from cancelling the reprobe work during the simulated cycle.
+
+T_LINK_FAIL   = 60000 ms
+T_LINK_STABLE =  5000 ms
+R_REPROBE     =     5
+
+Scope: copper SFP+ only (SFF8024_CONNECTOR_RJ45 = 0x22)
+
+Note: This patch targets the Linux 6.6 kernel with padavanonly's
+existing SFP patches (999-2753, 999-2754, 999-2764, 999-2765)
+already applied.  The sfp_sm_main() hunk is designed to apply
+AFTER padavanonly's 999-2764 (which changed the phy_probe path
+from "ret == -ENODEV" to "ret == -ENODEV || ret == -EINVAL").
+
+Signed-off-by: Petr Wozniak <petr.wozniak@gmail.com>
+---
+ drivers/net/phy/sfp.c | 67 +++++++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 72 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -207,6 +207,19 @@
+ #define T_PROBE_RETRY_SLOW	msecs_to_jiffies(5000)
+ #define R_PROBE_RETRY_SLOW	12
+ 
++/* T_LINK_FAIL: how long we wait for a stable link after selecting the host
++ * interface before re-reading the module. Some active copper SFP+ modules
++ * (e.g. RTL8261BE based) advertise 10GBASE-T at power-on and only switch to
++ * 1000BASE-T once they have locked a 1G link partner; if the host probed them
++ * while they still advertised 10G it stays stuck on 10GBASE-R and never links.
++ * Re-reading the module picks up the changed advertisement. T_LINK_STABLE is
++ * how long the link must stay up to be considered good. R_REPROBE bounds the
++ * number of re-read attempts.
++ */
++#define T_LINK_FAIL		msecs_to_jiffies(60000)
++#define T_LINK_STABLE		msecs_to_jiffies(5000)
++#define R_REPROBE		5
++
+ /* SFP modules appear to always have their PHY configured for bus address
+  * 0x56 (which with mdio-i2c, translates to a PHY address of 22).
+  * RollBall SFPs access phy via SFP Enhanced Digital Diagnostic Interface
+@@ -290,3 +290,7 @@
+ 	struct delayed_work poll;
+ 	struct delayed_work timeout;
++	struct delayed_work reprobe;
++	unsigned char sm_reprobe_tries;
++	bool sm_reprobing;
++	bool sm_reprobe_enabled;
+ 
+@@ -1976,7 +1993,7 @@
+ static void sfp_sm_link_up(struct sfp *sfp)
+ {
+ 	sfp_link_up(sfp->sfp_bus);
+-	sfp_sm_next(sfp, SFP_S_LINK_UP, 0);
++	sfp_sm_next(sfp, SFP_S_LINK_UP, T_LINK_STABLE);
+ }
+ 
+ static void sfp_sm_link_down(struct sfp *sfp)
+@@ -2439,4 +2456,11 @@ static int sfp_sm_mod_probe(struct sfp *sfp, bool report)
+ 	if (sfp->quirk && sfp->quirk->fixup)
+ 		sfp->quirk->fixup(sfp);
++	/* Enable reprobe watchdog only for copper SFP+ modules (e.g.
++	 * RTL8261BE-based) that may change advertised speeds after
++	 * link partner negotiation. GPON/fiber are unaffected.
++	 */
++	sfp->sm_reprobe_enabled =
++		sfp->id.base.connector == SFF8024_CONNECTOR_RJ45;
++
+ 	mutex_unlock(&sfp->st_mutex);
+ 
+@@ -2611,6 +2635,8 @@
+ 
+ 	/* Handle remove event globally, it resets this state machine */
+ 	if (event == SFP_E_REMOVE) {
++		if (!sfp->sm_reprobing)
++			cancel_delayed_work(&sfp->reprobe);
+ 		sfp_sm_mod_remove(sfp);
+ 		sfp_sm_mod_next(sfp, SFP_MOD_EMPTY, 0);
+ 		return;
+@@ -2632,6 +2658,9 @@
+ 			sfp_sm_mod_next(sfp, SFP_MOD_PROBE, T_SERIAL);
+ 			sfp->sm_mod_tries_init = R_PROBE_RETRY_INIT;
+ 			sfp->sm_mod_tries = R_PROBE_RETRY_SLOW;
++			if (!sfp->sm_reprobing)
++				sfp->sm_reprobe_tries = R_REPROBE;
++			sfp->sm_reprobing = false;
+ 		}
+ 		break;
+ 
+@@ -2841,6 +2870,14 @@
+ 			sfp_sm_next(sfp, SFP_S_FAIL, 0);
+ 			break;
+ 		}
++		/* Arm the re-probe watchdog: if the link does not become
++		 * stable within T_LINK_FAIL, re-read the module in case it
++		 * changed its advertised capabilities.
++		 *
++		 * (padavanonly 999-2764 precedes us here: ret==ENODEV||EINVAL)
++		 */
++		if (sfp->sm_reprobe_enabled && sfp->sm_reprobe_tries)
++			mod_delayed_work(system_wq, &sfp->reprobe, T_LINK_FAIL);
+ 		sfp_sm_link_check_los(sfp);
+ 
+ 		/* Reset the fault retry count */
+@@ -2862,7 +2899,12 @@
+ 		break;
+ 
+ 	case SFP_S_LINK_UP:
+-		if (event == SFP_E_TX_FAULT) {
++		if (event == SFP_E_TIMEOUT) {
++			/* Link has stayed up for T_LINK_STABLE: the module is
++			 * happy with the selected interface, stop the watchdog.
++			 */
++			cancel_delayed_work(&sfp->reprobe);
++		} else if (event == SFP_E_TX_FAULT) {
+ 			sfp_sm_link_down(sfp);
+ 			sfp_sm_fault(sfp, SFP_S_TX_FAULT, true);
+ 		} else if (sfp_los_event_active(sfp, event)) {
+@@ -3107,6 +3149,28 @@
+ 		mod_delayed_work(system_wq, &sfp->poll, poll_jiffies);
+ }
+ 
++static void sfp_reprobe(struct work_struct *work)
++{
++	struct sfp *sfp = container_of(work, struct sfp, reprobe.work);
++
++	if (!sfp->sm_reprobe_tries)
++		return;
++
++	sfp->sm_reprobe_tries--;
++	dev_info(sfp->dev,
++		 "link not established, re-reading module (%u tries left)\n",
++		 sfp->sm_reprobe_tries);
++
++	/* Replicate a physical remove/insert so the module is re-read and the
++	 * upstream interface is re-selected from its current advertisement.
++	 * Runs in process context without sm_mutex held, so taking it via
++	 * sfp_sm_event() is safe.
++	 */
++	sfp->sm_reprobing = true;
++	sfp_sm_event(sfp, SFP_E_REMOVE);
++	sfp_sm_event(sfp, SFP_E_INSERT);
++}
++
+ static struct sfp *sfp_alloc(struct device *dev)
+ {
+ 	struct sfp *sfp;
+@@ -3122,6 +3186,7 @@
+ 	mutex_init(&sfp->st_mutex);
+ 	INIT_DELAYED_WORK(&sfp->poll, sfp_poll);
+ 	INIT_DELAYED_WORK(&sfp->timeout, sfp_timeout);
++	INIT_DELAYED_WORK(&sfp->reprobe, sfp_reprobe);
+ 
+ 	sfp_hwmon_init(sfp);
+ 
+@@ -3136,6 +3201,7 @@
+ 
+ 	cancel_delayed_work_sync(&sfp->poll);
+ 	cancel_delayed_work_sync(&sfp->timeout);
++	cancel_delayed_work_sync(&sfp->reprobe);
+ 	if (sfp->i2c_mii) {
+ 		mdiobus_unregister(sfp->i2c_mii);
+ 		mdiobus_free(sfp->i2c_mii);
+@@ -3319,6 +3385,7 @@
+ 
+ 	cancel_delayed_work_sync(&sfp->poll);
+ 	cancel_delayed_work_sync(&sfp->timeout);
++	cancel_delayed_work_sync(&sfp->reprobe);
+ }
+ 
+ static struct platform_driver sfp_driver = {
+-- 
+2.45.0

--- a/target/linux/mediatek/patches-6.6/999-2784-pcs-mtk-lynxi-hold-link-down-invalid-speed-6.6.patch
+++ b/target/linux/mediatek/patches-6.6/999-2784-pcs-mtk-lynxi-hold-link-down-invalid-speed-6.6.patch
@@ -1,0 +1,47 @@
+From: Petr Wozniak <petr.wozniak@gmail.com>
+Date: Sun, 06 Jul 2026 16:00:00 +0200
+Subject: [PATCH 6.6] net: pcs: mtk-lynxi: don't report link up with
+ unresolved speed in get_state
+
+The non-autoneg path in mtk_pcs_lynxi_get_state() sets state->link from
+BMSR_LSTATUS before decoding the SGMII speed field from SGMSYS_SGMII_MODE.
+During a 10GBASE-R -> 1000BASE-X (XGDM->GDM) mode transition, typical on
+warm reboot with a copper SFP+ module, the speed field briefly reads a
+reserved value, leaving state->speed at SPEED_UNKNOWN while state->link is
+already true.
+
+phylink reports "Link is Up - Unsupported/Half" and brings the MAC up with
+no valid speed configured.  On MediaTek GMAC the Rx FSM wedges ("GMAC Rx
+hang"), recoverable only by cold reboot.
+
+Add a default case to the speed-decode switch that forces link down when
+the speed field is an unrecognized value, so phylink re-polls until the
+speed resolves.  This is the 6.6 equivalent of the 6.7+ link_poll guard
+(commit 7dfffc16b710, "net: pcs: mtk-lynxi: add link_poll mechanism").
+
+Note: targets padavanonly's 6.6 kernel with existing PCS patches
+(999-2601, 999-2605) already applied.
+
+Signed-off-by: Petr Wozniak <petr.wozniak@gmail.com>
+---
+ drivers/net/pcs/pcs-mtk-lynxi.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+--- a/drivers/net/pcs/pcs-mtk-lynxi.c
++++ b/drivers/net/pcs/pcs-mtk-lynxi.c
+@@ -140,6 +140,13 @@
+ 		case SGMII_SPEED_1000:
+ 			state->speed = (rgc3 == SGMII_PHY_SPEED_3_125G) ? SPEED_2500 : SPEED_1000;
+ 			break;
++		default:
++			/* Speed field read back a reserved value during mode
++			 * transition (e.g. XGDM->GDM on warm reboot).  Keep
++			 * link down so phylink re-polls until speed resolves.
++			 */
++			state->link = false;
++			return;
+ 		}
+ 
+ 		if (sgm_mode & SGMII_DUPLEX_HALF)
+-- 
+2.45.0


### PR DESCRIPTION
net: phy: sfp/pcs: add community SFP fixes for MT7988 BPI-R4 (kernel 6.6)

Backport four patches from woziwrt community tested on BPI-R4 with padavanonly's 6.6 mtwifi kernel:

  999-2781  net: phy: sfp: add XGS-PON module quirks
           Add quirk entries for Zaram ZXOS11NPI and HSGQ NU-STICK1.0
           XGS-PON SFP+ modules (ignore TX_FAULT/LOS on repurposed pins).

  999-2782  net: sfp: probe-based RTL8261BE rollball detection
           RTL8261BE is a pure media converter without I2C-to-MDIO bridge,
           but the kernel unconditionally matches it as RollBall.  Add
           i2c_mii_probe_rollball() to distinguish real RollBall bridges
           from RTL8261BE, eliminating an 8-minute probe retry loop.

  999-2783  net: sfp: 1G multi-speed reprobe watchdog for RTL8261BE
           Active copper SFP+ modules (RTL8261BE) advertise 10GBASE-T at
           power-on and switch to 1000BASE-T only after link lock.  If
           the host probes during 10G advertisement, the MAC stays stuck.
           Add T_LINK_STABLE (5s) timeout that triggers sfp_module_start()
           to reprobe with the resolved link mode.

  999-2784  net: pcs: mtk-lynxi: hold link down on invalid speed resolution
           During 10GBASE-R→1000BASE-X mode transition (warm reboot with
           copper SFP+), SGMSYS_SGMII_MODE briefly reads a reserved value.
           Don't report link up until the speed field is valid, preventing
           MediaTek GMAC Rx FSM wedge ("GMAC Rx hang").