### PR TITLE
mediatek: sfp: support 2500base-X on ODI DFP-34X-2C2

### DIFF
--- a/target/linux/mediatek/patches-6.6/999-2786-sfp-odi-dfp-34x-2c2-2500basex.patch
+++ b/target/linux/mediatek/patches-6.6/999-2786-sfp-odi-dfp-34x-2c2-2500basex.patch
@@ -1,0 +1,48 @@
+From: ItsLucas <itslucas@itslucas.me>
+Date: Fri, 31 Jul 2026 00:00:00 +0000
+Subject: [PATCH 6.6] net: phy: sfp: support 2500base-X on ODI DFP-34X-2C2
+
+The ODI DFP-34X-2C2 GPON stick is electrically capable of running its
+host-side interface at 2500BASE-X, but its EEPROM does not advertise
+that mode, so the SFP layer only offers 1000BASE-X to the MAC/switch.
+
+Verified on a TP-Link TL-7DR7299 v1 (MT7988 + RTL8372N, SFP on SerDes1 /
+switch port 5) with an ODI DFP-34X-2C2 HW V2.0, FW V1.1.8-240408 in GPON
+mode:
+
+  - On hot-plug the kernel reads a stable identity ("ODI" /
+    "DFP-34X-2C2"), reports
+    "sfp: support mode 00,00000000,00000200,00006040", and the RTL837x
+    driver logs "1000base-x SFP module inserted". Port 5 links at
+    1000 Mbps full duplex and PPPoE over the ISP VLAN comes up.
+  - Forcing only the switch SerDes mode with
+    "swconfig dev switch0 set serdes1_force_mode 22" (SerDes1 -> 0x16)
+    on the exact same hardware, module, optics, VLAN and PPPoE
+    configuration yields a stable 2500 Mbps full duplex link, and PPPoE
+    reconnects successfully.
+
+So the link, the board routing and the module all support 2.5G; the only
+defect is the advertised host-side mode set. LOS and TX_FAULT behave
+correctly (LOS low, TX_DISABLE output low at link up), and the module is
+accepted by the RTL837x driver, so no alarm-suppression or forced-mode
+bypass fixup is warranted. A modes-only quirk is therefore the minimal
+correct fix.
+
+Signed-off-by: ItsLucas <itslucas@itslucas.me>
+---
+ drivers/net/phy/sfp.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -616,6 +616,10 @@ static const struct sfp_quirk sfp_quirks
+ 	SFP_QUIRK("Lantech", "8330-265D", sfp_quirk_2500basex,
+ 		  sfp_fixup_ignore_los),
+ 
++	// ODI DFP-34X-2C2 can operate at 2500base-X, but does not advertise
++	// that host-side mode in its EEPROM.
++	SFP_QUIRK_M("ODI", "DFP-34X-2C2", sfp_quirk_2500basex),
++
+ 	SFP_QUIRK_M("UBNT", "UF-INSTANT", sfp_quirk_ubnt_uf_instant),
+ 
+ 	// Walsun HXSX-ATR[CI]-1 don't identify as copper, and use the


### PR DESCRIPTION
## What

Adds a modes-only SFP quirk for the ODI DFP-34X-2C2 GPON stick:

```c
SFP_QUIRK_M("ODI", "DFP-34X-2C2", sfp_quirk_2500basex),
```

New patch: `target/linux/mediatek/patches-6.6/999-2786-sfp-odi-dfp-34x-2c2-2500basex.patch`

## Why

The module is electrically capable of 2500BASE-X on the host side, but its EEPROM does not advertise that mode, so the SFP layer only offers 1000BASE-X to the MAC/switch and the link settles at 1G.

## Test platform

- TP-Link TL-7DR7299 v1 (MT7988) + Realtek RTL8372N
- SFP on RTL8372N SerDes1, logical switch port 5
- ODI DFP-34X-2C2, HW V2.0, FW V1.1.8-240408, GPON mode
- Base firmware `30fbc1d6deba23c0e850185021e9ee42214925eb` (`r33541-30fbc1d6de`), target `mediatek/filogic_a73`, Linux 6.6.94, rtl837x `6.6.94.2026.05.25~a1650c6a-r1`

SFP port was isolated from the LAN bridge during testing (VLAN 2 untagged for stick management, VLAN 111 tagged for the ISP PPPoE path) so PPPoE success acts as an end-to-end data-path check.

## Evidence

**Baseline (no module):** `serdes1_force_mode=1` (unforced), Serdes1 `0x1f`, port 5 down, MOD_DEF0 high.

**A — automatic hot-plug, no force:** EEPROM read is stable and exact:

```
vendor: ODI
part:   DFP-34X-2C2
serial: XPON25010691
date:   250117
```

```
sfp sfp0: sfp: support mode 00,00000000,00000200,00006040
rtl837x-gsw mdio-bus:1d: 1000base-x SFP module inserted
rtl837x-gsw mdio-bus:1d: SFP module auto start
```

Result: Serdes1 `0x4`, port 5 up at **1000 Mbps** full duplex, MOD_DEF0 low, LOS low, TX_DISABLE output low. PPPoE over `eth2.111` completed PAP auth, IPv4/IPv6/routes/DNS installed.

**D — force 2.5G only (same module, optics, VLANs, PPPoE config):**

```sh
swconfig dev switch0 set serdes1_force_mode 22
```

Serdes1 `0x4` -> `0x16`; after ~60 s port 5 is up at **2500 Mbps** full duplex, LOS low, TX_DISABLE output low, and PPPoE automatically reconnected and authenticated.

## Interpretation

The board routing, optics, module and data path all support 2.5G. The only defect is the advertised host-side mode set, so a modes-only quirk is the minimal fix.

Explicitly **not** included, because nothing in the traces justifies it:

- no `ignore_los` / `ignore_tx_fault` fixup (both pins behave correctly at link up)
- no device tree change and no board-wide SerDes default
- no bypass of the RTL837x `Incompatible SFP module inserted` path (the module is already accepted)

Placement in the quirk table keeps the existing rough alphabetical ordering (after `Lantech`, before `UBNT`). The patch applies cleanly to `drivers/net/phy/sfp.c` on top of the existing `999-27xx` SFP patch series.

## Known limitations

- Force-before-insert was not tested; the module became mechanically stuck in the cage, so only force-after-insert was exercised.
- The quirk itself has been verified to apply cleanly against the 6.6.94 tree and the resulting image has been flashed and re-validated on hardware.