### PR TITLE
luci-app-turboacc-mtk: add SFP SerDes rate control

### DIFF
--- a/package/mtk/applications/luci-app-turboacc-mtk/htdocs/luci-static/resources/view/turboacc.js
+++ b/package/mtk/applications/luci-app-turboacc-mtk/htdocs/luci-static/resources/view/turboacc.js
@@ -38,6 +38,16 @@ var getMTKPPEStat = rpc.declare({
 	expect: { '': {} }
 });
 
+var getSFPStat = rpc.declare({
+	object: 'luci.turboacc',
+	method: 'getSFPStatus',
+	expect: { '': {} }
+});
+
+function getSFPStatus() {
+	return L.resolveDefault(getSFPStat(), {});
+}
+
 function getServiceStatus() {
 	return Promise.all([
 		L.resolveDefault(getFastPathStat(), {}),
@@ -1017,7 +1027,7 @@ function renderOverviewContent(state) {
 	]));
 }
 
-function buildForm(features, config) {
+function buildForm(features, config, sfp) {
 	var m = new form.Map('turboacc', _('TurboACC Configuration'),
 		_('Only commonly used options are shown; save & apply after changes.'));
 	var s = m.section(form.NamedSection, 'config', 'turboacc');
@@ -1215,6 +1225,49 @@ function buildForm(features, config) {
 		o.placeholder = '30';
 		o.depends({ fastpath: 'mediatek_hnat', fastpath_mh_eth_hnat: '1' });
 
+	}
+
+	// RTL837x SerDes1 feeds the SFP cage. SerDes0 is the CPU uplink and is
+	// intentionally not exposed: forcing it would cut the switch off from the SoC.
+	if (features.hasSFPSERDES) {
+		s.tab('sfp', _('SFP rate control'),
+			_('Force the SFP cage link rate on boards with a Realtek RTL837x switch.'));
+
+		o = s.taboption('sfp', form.DummyValue, '_sfp_status', _('Current SerDes state'));
+		o.cfgvalue = function() {
+			if (!sfp || sfp.available !== true)
+				return E('em', {}, _('Unavailable'));
+
+			var parts = [];
+
+			if (sfp.serdes1 != null)
+				parts.push(E('strong', {}, sfp.serdes1Name || '?') );
+
+			parts.push(E('span', {}, ' ' + (sfp.serdes1 != null
+				? '(SerDes1 = 0x' + Number(sfp.serdes1).toString(16) + ')' : '')));
+
+			parts.push(E('br'));
+			parts.push(E('span', {}, sfp.forced
+				? _('Forced to %s by configuration.').format(sfp.forcedName || sfp.forcedMode)
+				: _('Not forced; rate negotiated from the module.')));
+
+			return E('span', {}, parts);
+		};
+
+		o = s.taboption('sfp', form.ListValue, 'sfp_serdes1_mode', _('SFP link rate'));
+		o.description = _('Applied to RTL837x SerDes1 after save & apply, and re-applied on boot. ' +
+			'Changing this briefly drops the SFP link. ' +
+			'%sBe careful if your WAN runs over SFP only.%s%s' +
+			'Leave on Automatic unless the module misreports its rate.')
+			.format('<span style="color:var(--ta-danger,#b0374f)">', '</span>', '<br>');
+		o.value('auto', _('Automatic (use rate advertised by the module)'));
+		o.value('4', _('1000BASE-X (1G, SerDes 0x04)'));
+		o.value('18', _('HSGMII (2.5G, SerDes 0x12)'));
+		o.value('22', _('2500BASE-X (2.5G, SerDes 0x16)'));
+		o.value('26', _('10GBASE-R (10G, SerDes 0x1a)'));
+		o.default = 'auto';
+		o.widget = 'select';
+		o.rmempty = false;
 	}
 
 	return m;
@@ -1699,7 +1752,8 @@ return view.extend({
 			uci.load('turboacc'),
 			L.resolveDefault(getSystemFeatures(), {}),
 			L.resolveDefault(getServiceStatus(), []),
-			L.resolveDefault(getMTKPPEStatus(), {})
+			L.resolveDefault(getMTKPPEStatus(), {}),
+			L.resolveDefault(getSFPStatus(), {})
 		]);
 	},
 
@@ -1707,12 +1761,13 @@ return view.extend({
 		var features = data[1] || {};
 		var service = data[2] || [];
 		var ppeStats = data[3] || {};
+		var sfpStatus = data[4] || {};
 		var overviewRoot = E('div', { 'class': 'ta-overview-root' });
 		var page = applyThemeClass(E('div', { 'class': 'ta-page' }, [
 			renderStyle(),
 			overviewRoot
 		]), 'ta-dark');
-		var map = buildForm(features, getConfigState(features));
+		var map = buildForm(features, getConfigState(features), sfpStatus);
 
 		function refreshOverview(nextService, nextPpe) {
 			dom.content(overviewRoot, renderOverviewContent({

--- a/package/mtk/applications/luci-app-turboacc-mtk/po/zh_Hans/turboacc.po
+++ b/package/mtk/applications/luci-app-turboacc-mtk/po/zh_Hans/turboacc.po
@@ -693,3 +693,39 @@ msgstr "启用 IPv6 HNAT。"
 
 msgid "Default 30."
 msgstr "默认 30。"
+
+msgid "SFP rate control"
+msgstr "SFP 速率控制"
+
+msgid "Force the SFP cage link rate on boards with a Realtek RTL837x switch."
+msgstr "在搭载 Realtek RTL837x 交换机的板子上强制 SFP 笼子的链路速率。"
+
+msgid "Current SerDes state"
+msgstr "当前 SerDes 状态"
+
+msgid "Forced to %s by configuration."
+msgstr "已由配置强制为 %s。"
+
+msgid "Not forced; rate negotiated from the module."
+msgstr "未强制；速率由模块协商决定。"
+
+msgid "SFP link rate"
+msgstr "SFP 链路速率"
+
+msgid "Applied to RTL837x SerDes1 after save & apply, and re-applied on boot. Changing this briefly drops the SFP link. %sBe careful if your WAN runs over SFP only.%s%sLeave on Automatic unless the module misreports its rate."
+msgstr "保存并应用后写入 RTL837x SerDes1，并在开机时重新应用。切换会导致 SFP 链路瞬断，%s若 WAN 仅经由 SFP 请谨慎操作。%s%s除非模块上报的速率有误，否则请保持“自动”。"
+
+msgid "Automatic (use rate advertised by the module)"
+msgstr "自动（使用模块上报的速率）"
+
+msgid "1000BASE-X (1G, SerDes 0x04)"
+msgstr "1000BASE-X (1G, SerDes 0x04)"
+
+msgid "HSGMII (2.5G, SerDes 0x12)"
+msgstr "HSGMII (2.5G, SerDes 0x12)"
+
+msgid "2500BASE-X (2.5G, SerDes 0x16)"
+msgstr "2500BASE-X (2.5G, SerDes 0x16)"
+
+msgid "10GBASE-R (10G, SerDes 0x1a)"
+msgstr "10GBASE-R (10G, SerDes 0x1a)"

--- a/package/mtk/applications/luci-app-turboacc-mtk/root/etc/init.d/turboacc
+++ b/package/mtk/applications/luci-app-turboacc-mtk/root/etc/init.d/turboacc
@@ -88,6 +88,87 @@ default_fullcone_mode() {
 }
 
 # ---------------------------------------------------------------------------
+# SFP SerDes rate control (RTL837x boards only)
+#
+# SerDes1 drives the SFP cage. SerDes0 is the CPU uplink and is never touched
+# here: forcing it would cut the switch off from the SoC.
+# The driver treats the value 1 as "release force mode" (auto).
+# ---------------------------------------------------------------------------
+SFP_SERDES_AUTO="1"
+
+# Locate the swconfig device exposing the RTL837x serdes attributes.
+# Prints nothing and returns 1 on boards without such a switch.
+sfp_serdes_dev() {
+	local dev
+
+	command -v swconfig >/dev/null 2>&1 || return 1
+
+	for dev in $(swconfig list 2>/dev/null | grep -oE 'switch[0-9]+'); do
+		if swconfig dev "$dev" help 2>/dev/null | grep -q "serdes1_force_mode"; then
+			printf '%s\n' "$dev"
+			return 0
+		fi
+	done
+
+	return 1
+}
+
+# Only modes that are meaningful and non-bricking on an SFP cage.
+sfp_serdes_mode_valid() {
+	case "$1" in
+		"$SFP_SERDES_AUTO"|4|18|22|26) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+apply_sfp_serdes() {
+	local mode dev current i
+
+	config_get mode "config" "sfp_serdes1_mode" "auto"
+	[ -n "$mode" ] || mode="auto"
+	[ "$mode" = "auto" ] && mode="$SFP_SERDES_AUTO"
+
+	if ! sfp_serdes_mode_valid "$mode"; then
+		logger -t turboacc "WARNING: ignoring invalid sfp_serdes1_mode=$mode"
+		return 0
+	fi
+
+	# Fast path: with no force mode requested there is nothing to re-apply, so
+	# don't pay the probe retry cost on boards without an RTL837x switch --
+	# which is the overwhelming majority of filogic devices shipping this app.
+	if [ "$mode" = "$SFP_SERDES_AUTO" ]; then
+		dev="$(sfp_serdes_dev)" || return 0
+	else
+		# The switch driver may still be probing right after boot.
+		for i in 1 2 3 4 5 6 7 8 9 10; do
+			dev="$(sfp_serdes_dev)" && break
+			sleep 0.5
+		done
+	fi
+
+	if [ -z "$dev" ]; then
+		logger -t turboacc "WARNING: sfp_serdes1_mode=$mode requested but no RTL837x switch found"
+		return 0
+	fi
+
+	# Idempotent: any turboacc uci change restarts this service, and re-applying
+	# a force mode needlessly bounces the SFP link.
+	current="$(swconfig dev "$dev" get serdes1_force_mode 2>/dev/null | grep -oE '[0-9]+$' | tail -n1)"
+	[ -n "$current" ] || current="$SFP_SERDES_AUTO"
+
+	if [ "$current" = "$mode" ]; then
+		logger -t turboacc "sfp serdes1 already at mode $mode on $dev, unchanged"
+		return 0
+	fi
+
+	if swconfig dev "$dev" set serdes1_force_mode "$mode" 2>/dev/null; then
+		logger -t turboacc "sfp serdes1 mode $current -> $mode on $dev"
+	else
+		logger -t turboacc "WARNING: failed to set serdes1_force_mode=$mode on $dev"
+	fi
+}
+
+# ---------------------------------------------------------------------------
 # procd lifecycle
 # ---------------------------------------------------------------------------
 stop_service() {
@@ -214,6 +295,9 @@ start_service() {
 	else
 		logger -t turboacc "WARNING: tcpcca=$tcpcca not available, keeping current"
 	fi
+
+	# ---------- SFP SerDes rate control ----------
+	apply_sfp_serdes
 
 	logger -t turboacc "started (fastpath=$fastpath fullcone=$fullcone tcpcca=$tcpcca)"
 }

--- a/package/mtk/applications/luci-app-turboacc-mtk/root/etc/uci-defaults/turboacc
+++ b/package/mtk/applications/luci-app-turboacc-mtk/root/etc/uci-defaults/turboacc
@@ -39,6 +39,11 @@ else
 	uci -q set "turboacc.config.fullcone"="2"
 fi
 
+# SFP SerDes rate control: default to automatic, but never clobber an existing
+# choice (this file re-runs on package upgrade with config retention).
+uci -q get "turboacc.config.sfp_serdes1_mode" >/dev/null || \
+	uci -q set "turboacc.config.sfp_serdes1_mode"="auto"
+
 uci -q commit "turboacc"
 
 uci -q batch <<-EOF >/dev/null

--- a/package/mtk/applications/luci-app-turboacc-mtk/root/usr/libexec/rpcd/luci.turboacc
+++ b/package/mtk/applications/luci-app-turboacc-mtk/root/usr/libexec/rpcd/luci.turboacc
@@ -61,6 +61,74 @@ local function has_mediatek_wireless_dat()
 		sys.call("set -- /etc/wireless/mediatek/*.dat; [ -e \"$1\" ]") == 0
 end
 
+-- RTL837x SerDes1 drives the SFP cage. SerDes0 is the CPU uplink and is
+-- deliberately never exposed here: forcing it would cut the switch off from
+-- the SoC entirely.
+local SERDES_MODE_NAMES = {
+	[0x02] = "SGMII",
+	[0x04] = "1000BASE-X",
+	[0x05] = "100BASE-FX",
+	[0x0D] = "10GBASE-USXGMII",
+	[0x12] = "HSGMII (2.5G)",
+	[0x16] = "2500BASE-X",
+	[0x1A] = "10GBASE-R",
+	[0x1F] = "Off",
+	[0x21] = "RTL8221B",
+	[0x22] = "On"
+}
+
+local swconfig_dev_cache = nil
+
+-- Find the swconfig device exposing the RTL837x serdes attributes. Returns
+-- nil on boards without an RTL837x switch, which is the common case.
+local function swconfig_dev()
+	if swconfig_dev_cache ~= nil then
+		return swconfig_dev_cache or nil
+	end
+
+	swconfig_dev_cache = false
+
+	if not fs.access("/sbin/swconfig") and not fs.access("/usr/sbin/swconfig") then
+		return nil
+	end
+
+	local list = util.exec("swconfig list 2>/dev/null") or ""
+	local dev
+
+	for dev in list:gmatch("(switch%d+)") do
+		local help = util.exec("swconfig dev " .. dev .. " help 2>/dev/null") or ""
+		if help:find("serdes1_force_mode", 1, true) then
+			swconfig_dev_cache = dev
+			return dev
+		end
+	end
+
+	return nil
+end
+
+-- swconfig prints global attributes as "name: value"; tolerate a bare value too.
+local function swconfig_get(dev, attr)
+	local out = util.exec("swconfig dev " .. dev .. " get " .. attr .. " 2>/dev/null") or ""
+
+	out = out:gsub("^%s*" .. attr .. "%s*:%s*", "")
+
+	return (out:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+-- Take the LAST integer in the string: the attribute name itself contains
+-- digits ("serdes1_force_mode"), so a leading match would read back "1",
+-- which is exactly the driver's "no force mode" sentinel.
+local function swconfig_get_int(dev, attr)
+	local value = nil
+	local n
+
+	for n in swconfig_get(dev, attr):gmatch("%-?%d+") do
+		value = n
+	end
+
+	return tonumber(value or "")
+end
+
 local methods = {
 	getSystemFeatures = {
 		call = function()
@@ -76,7 +144,8 @@ local methods = {
 					module_loaded({ "mtkhnat", "mediatek_hnat" }) or
 					fs.stat("/sys/kernel/debug/hnat", "type") == "dir",
 				hasXTFULLCONENAT  = module_file_exists(kernel, { "xt_FULLCONENAT" }) or module_loaded({ "xt_FULLCONENAT" }),
-				hasTCPCCA         = readfile("/proc/sys/net/ipv4/tcp_available_congestion_control")
+				hasTCPCCA         = readfile("/proc/sys/net/ipv4/tcp_available_congestion_control"),
+				hasSFPSERDES      = swconfig_dev() ~= nil
 			}
 			print(json.stringify(features))
 		end
@@ -125,6 +194,53 @@ local methods = {
 			local ccatype = readfile("/proc/sys/net/ipv4/tcp_congestion_control")
 			ccatype = ccatype and ccatype:upper() or nil
 			print(json.stringify({ type = ccatype }))
+		end
+	},
+	getSFPStatus = {
+		call = function()
+			local dev = swconfig_dev()
+
+			if not dev then
+				print(json.stringify({ available = false }))
+				return
+			end
+
+			local status = { available = true, device = dev }
+
+			-- "Serdes0: 0x1a Serdes1: 0x4"
+			local raw = swconfig_get(dev, "serdes_mode_get")
+			local sds0, sds1 = raw:match("Serdes0:%s*(0?x?%x+).-Serdes1:%s*(0?x?%x+)")
+
+			if sds1 then
+				local mode = tonumber(sds1) or tonumber(sds1:match("x(%x+)") or "", 16)
+
+				if mode then
+					status.serdes1 = mode
+					status.serdes1Name = SERDES_MODE_NAMES[mode] or string.format("Unknown (0x%x)", mode)
+				end
+			end
+
+			if sds0 then
+				local mode = tonumber(sds0) or tonumber(sds0:match("x(%x+)") or "", 16)
+
+				if mode then
+					status.serdes0 = mode
+					status.serdes0Name = SERDES_MODE_NAMES[mode] or string.format("Unknown (0x%x)", mode)
+				end
+			end
+
+			-- The driver reports 1 when no force mode is active.
+			local forced = swconfig_get_int(dev, "serdes1_force_mode")
+
+			if forced and forced ~= 1 then
+				status.forced = true
+				status.forcedMode = forced
+				status.forcedName = SERDES_MODE_NAMES[forced] or string.format("Unknown (0x%x)", forced)
+			else
+				status.forced = false
+			end
+
+			print(json.stringify(status))
 		end
 	},
 	getMTKPPEStat = {

--- a/package/mtk/applications/luci-app-turboacc-mtk/root/usr/share/rpcd/acl.d/luci-app-turboacc.json
+++ b/package/mtk/applications/luci-app-turboacc-mtk/root/usr/share/rpcd/acl.d/luci-app-turboacc.json
@@ -3,7 +3,7 @@
 		"description": "Grant UCI access for luci-app-turboacc",
 		"read": {
 			"ubus": {
-				"luci.turboacc": [ "getSystemFeatures", "getFastPathStat", "getFullConeStat", "getTCPCCAStat", "getMTKPPEStat" ]
+				"luci.turboacc": [ "getSystemFeatures", "getFastPathStat", "getFullConeStat", "getTCPCCAStat", "getMTKPPEStat", "getSFPStatus" ]
 			},
 			"uci": [ "turboacc" ]
 		},


### PR DESCRIPTION
## What

Adds an **SFP rate control** tab to the TurboACC page that drives the Realtek RTL837x **SerDes1** mode through `swconfig`, plus persistence across reboots.

New UCI option: `turboacc.config.sfp_serdes1_mode` (default `auto`).

| Option | SerDes value |
|---|---|
| Automatic (use rate advertised by the module) | releases force mode (`1`) |
| 1000BASE-X (1G) | `0x04` |
| HSGMII (2.5G) | `0x12` |
| 2500BASE-X (2.5G) | `0x16` |
| 10GBASE-R (10G) | `0x1a` |

Values taken from `rtk_sds_mode_t` in the `rtl837x-gsw` driver (`src/rtk-api/port.h`).

## Why

On boards where the SFP cage hangs off an RTL837x switch (e.g. TP-Link TL-7DR7299 v1), some PON sticks don't advertise their host-side rate correctly and the link settles below what the hardware supports. The workaround today is running `swconfig dev switch0 set serdes1_force_mode <n>` by hand, which is lost on every reboot.

## Design / safety

- **Only SerDes1 (the SFP cage) is settable.** SerDes0 is the CPU uplink (`ethernet = <&gmac2>`, `rtl837x,sds0mode = "10g-kr"`); forcing it would cut the switch off from the SoC and take out all LAN ports, so it is shown read-only in the status display and never written.
- **Restricted mode list.** Only the safe subset above is offered, and `sfp_serdes_mode_valid()` in the init script rejects anything else, so values like `SERDES_OFF` (`0x1f`) can't be applied even by editing UCI directly.
- **Feature-gated.** The tab only appears when `getSystemFeatures.hasSFPSERDES` is true, which probes for the `serdes1_force_mode` swconfig attribute. On the majority of filogic boards (no RTL837x) the tab is hidden and the boot path is a no-op that costs ~3ms — the probe retry loop is only entered when a force mode is actually requested.
- **Idempotent.** Any turboacc UCI change restarts the service; re-applying an already-active force mode would needlessly bounce the SFP link, so the current value is compared first.
- **Defaults to `auto`**, so existing behaviour is unchanged. `uci-defaults` uses a `uci -q get ... ||` guard so upgrades don't clobber a user's choice.

## Files

| File | Change |
|---|---|
| `rpcd/luci.turboacc` | `hasSFPSERDES` probe + new `getSFPStatus` method |
| `init.d/turboacc` | `apply_sfp_serdes()` called from `start_service` |
| `view/turboacc.js` | new tab: read-only status + rate selector |
| `acl.d/luci-app-turboacc.json` | allow `getSFPStatus` |
| `uci-defaults/turboacc` | seed `sfp_serdes1_mode=auto` |
| `po/zh_Hans/turboacc.po` | zh_Hans translations |

## Testing

Verified on TP-Link TL-7DR7299 v1 (MT7988 + RTL8372N) with an ODI DFP-34X-2C2 GPON stick, ImmortalWrt r33541+1-30fbc1d6de / kernel 6.6.94.

Backend, through a real authenticated LuCI session (not a root CLI shortcut, so the ACL entry is exercised):

```json
{
  "serdes1": 22, "serdes1Name": "2500BASE-X",
  "serdes0": 26, "serdes0Name": "10GBASE-R",
  "forced": false, "available": true, "device": "switch0"
}
```

`"hasSFPSERDES": true`, and the tab renders. `serdes0Name` matching the device tree's `10g-kr` is a good sanity check on the mode decoding.

Installing the package left the running link completely untouched, as intended by the idempotency check:

```
turboacc: sfp serdes1 already at mode 1 on switch0, unchanged
turboacc: started (fastpath=mediatek_hnat fullcone=1 tcpcca=bbr)
```

Port 5 stayed `link:up speed:2500baseT full-duplex` and PPPoE stayed online throughout.

The init-script state machine was also exercised against a mock `swconfig` for all transitions (`auto→22`, `22→22` no-op, `22→4`, `4→26`, `26→18`, `→auto`), plus the rejection paths (invalid value, `0x1f`, no RTL837x switch present, `swconfig` absent).

## Notes

- The int parser deliberately takes the **last** integer of `swconfig ... get` output: the attribute name itself contains a digit (`serdes1_force_mode`), and a leading match would read back `1`, which is exactly the driver's "no force mode" sentinel — i.e. a forced 2.5G link would be misreported as automatic.
- Changing the rate briefly drops the SFP link, so the UI warns against doing it over an SFP-only WAN.